### PR TITLE
Save CUDA tensors in caching allocator

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
         apt-get update
         apt-get install -y --no-install-recommends build-essential git cmake libtool-bin wget autoconf automake
         conda uninstall -y pytorch torchvision
-        conda install -y pytorch torchvision cpuonly -c pytorch-nightly
+        pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     - name: Get UCX
       run: |
         git clone ${OPENUCX_LINK} /tmp/ucx


### PR DESCRIPTION
Change the way input and output tensors are stored in PG. For CUDA tensors we can use special API to mark tensor used in external stream so that caching allocator will not free memory while collective is in progress