### PR TITLE
std::thread is used without #include <thread>

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <thread>
 #include <vector>
 
 #include <pybind11/chrono.h>


### PR DESCRIPTION
This file will fail to build if I comment out the
```C++
#include <torch/python.h>
#include <pybind11/chrono.h>
```