### PR TITLE
Avoid using deleteKey when creating team

### DIFF
--- a/include/torch_ucc_comm.hpp
+++ b/include/torch_ucc_comm.hpp
@@ -44,6 +44,7 @@ struct torch_ucc_oob_coll_info_t {
   int rank;
   int size;
   void* rbuf;
+  int msgid;
   size_t msglen;
   std::string getKey(std::string key) {
     return std::to_string(comm_id)+key;


### PR DESCRIPTION
I am trying to run PyTorch's distributed unit tests with this UCC backend. And I am seeing failures caused by `FileStore` not supporting `deleteKey`, so I created this PR to get rid of `deleteKey` usage.