### PR TITLE
Use shared_ptr to store oob

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -272,7 +272,7 @@ class ProcessGroupUCC : public ProcessGroup {
   }
 
  protected:
-  torch_ucc_oob_coll_info_t oob;
+  std::shared_ptr<torch_ucc_oob_coll_info_t> oob;
   std::shared_ptr<CommPG> comm;
   uint32_t comm_id;
   std::vector<ucp_ep_h> eps;
@@ -285,6 +285,7 @@ class ProcessGroupUCC : public ProcessGroup {
 };
 
 class CommPG {
+  std::shared_ptr<torch_ucc_oob_coll_info_t> oob;
   CommUCX ucx_comm;
   CommUCC ucc_comm;
   c10::DeviceIndex device_index;
@@ -297,22 +298,16 @@ class CommPG {
 
  public:
   c10::DeviceIndex cuda_device_index;
-  CommPG(torch_ucc_oob_coll_info_t* oob_info,
+  CommPG(std::shared_ptr<torch_ucc_oob_coll_info_t> oob_info,
       c10::Device dev);
 
   ~CommPG();
 
-  void ucx_connect_eps(
-      std::vector<ucp_ep_h>& eps,
-      torch_ucc_oob_coll_info_t* oob);
+  void ucx_connect_eps(std::vector<ucp_ep_h>& eps);
 
-  void ucx_disconnect_eps(
-      std::vector<ucp_ep_h>& eps,
-      torch_ucc_oob_coll_info_t* oob);
+  void ucx_disconnect_eps(std::vector<ucp_ep_h>& eps);
 
-  void ucc_create_team(
-      ucc_team_h& team,
-      torch_ucc_oob_coll_info_t* oob_info);
+  void ucc_create_team(ucc_team_h& team);
 
   void ucc_destroy_team(ucc_team_h& team);
 
@@ -341,7 +336,7 @@ class CommPG {
   static std::shared_ptr<CommPG> get_comm(
       uint32_t& id,
       c10::Device dev,
-      torch_ucc_oob_coll_info_t *oob);
+      std::shared_ptr<torch_ucc_oob_coll_info_t> oob);
 
   void progress_loop();
 

--- a/include/torch_ucc_comm.hpp
+++ b/include/torch_ucc_comm.hpp
@@ -75,7 +75,7 @@ class CommUCC : public CommBase {
 
  public:
   void progress() override;
-  CommUCC(torch_ucc_oob_coll_info_t* oob_info);
+  CommUCC(std::shared_ptr<torch_ucc_oob_coll_info_t> oob_info);
   ~CommUCC();
 };
 

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -119,7 +119,7 @@ ucc_status_t oob_allgather_free(void* req) {
   return UCC_OK;
 }
 
-CommUCC::CommUCC(torch_ucc_oob_coll_info_t* oob_info) {
+CommUCC::CommUCC(std::shared_ptr<torch_ucc_oob_coll_info_t> oob_info) {
   ucc_lib_config_h lib_config;
   ucc_context_config_h context_config;
   ucc_lib_params_t lib_params;
@@ -179,7 +179,7 @@ CommUCC::CommUCC(torch_ucc_oob_coll_info_t* oob_info) {
   context_params.oob.allgather = oob_allgather;
   context_params.oob.req_test = oob_allgather_test;
   context_params.oob.req_free = oob_allgather_free;
-  context_params.oob.coll_info = oob_info;
+  context_params.oob.coll_info = oob_info.get();
   ucc_context_create(lib, &context_params, context_config, &context);
   ucc_context_config_release(context_config);
   if (st != UCC_OK) {


### PR DESCRIPTION
Currently, oob is owned by `ProcessGroupUCC`, but `CommPG` is owned by a shared pointer whose lifetime can be longer than ProcessGroupUCC. This bug causes segmentation fault at exit (I observe this behavior during an exception), because `~CommPG` needs a valid oob to destroy UCC context.

This PR changes the ownership of oob to a shared pointer, and make CommPG to store one instance of that pointer to make sure the lifetime of oob is always longer than `CommPG`.