### PR TITLE
fix pt2pt runtime issue and add several param bench to CI test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 env:
   OPENUCX_LINK: https://github.com/openucx/ucx.git
   UCC_LINK: https://github.com/openucx/ucc.git
+  PARAM_LINK: https://github.com/facebookresearch/param
 
 jobs:
   tests:
@@ -21,7 +22,7 @@ jobs:
     - name: Get UCX
       run: |
         git clone ${OPENUCX_LINK} /tmp/ucx
-        cd /tmp/ucx &&
+        cd /tmp/ucx
         ./autogen.sh
         ./contrib/configure-release-mt --without-java --disable-numa --prefix=/opt/ucx
         make -j install
@@ -53,3 +54,27 @@ jobs:
         /bin/bash ./test/start_test.sh ./test/torch_allreduce_test.py --backend=gloo
         echo "UCC broadcast"
         /bin/bash ./test/start_test.sh ./test/torch_bcast_test.py --backend=gloo
+    - name: Test PARAM
+      run: |
+        git clone ${PARAM_LINK} /tmp/param
+        export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucc/lib:$LD_LIBRARY_PATH
+        echo "PARAM-Comms Allreduce w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_reduce
+        echo "PARAM-Comms Alltoall w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_to_all
+        echo "PARAM-Comms Alltoallv w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_to_allv
+        echo "PARAM-Comms Broadcast w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective broadcast
+        echo "PARAM-Comms Allgather w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_gather
+        echo "PARAM-Comms Quantized Allreduce w/ UCC (use of c10d future)"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --bitwidth 16 --collective all_reduce
+        echo "PARAM-Comms Non-blocking Allreduce w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --z 0 --collective all_reduce
+        echo "PARAM-Comms Non-blocking Alltoall w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --z 0 --collective all_to_all
+        echo "PARAM-Comms Non-blocking Alltoallv w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --z 0 --collective all_to_allv
+        echo "PARAM-Comms Pt2pt w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --pt2pt one2one


### PR DESCRIPTION
Summary:
- ensure entry_ is valid since small pt2pt Work UCC may not create ProgressEntry as the request is completed fast
- create future_ object for pt2pt work
- add param bench to CI test to cover pt2pt test and several collective tests (combine #27 )

Differential Revision: D30284930

