### PR TITLE
 fix pt2pt enqueue and hang issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,6 +54,8 @@ jobs:
         /bin/bash ./test/start_test.sh ./test/torch_allreduce_test.py --backend=gloo
         echo "UCC broadcast"
         /bin/bash ./test/start_test.sh ./test/torch_bcast_test.py --backend=gloo
+        echo "UCC pt2pt"
+        /bin/bash ./test/start_test.sh ./test/torch_pt2pt_test.py --backend=gloo
     - name: Test PARAM
       run: |
         git clone ${PARAM_LINK} /tmp/param
@@ -77,4 +79,4 @@ jobs:
         echo "PARAM-Comms Non-blocking Alltoallv w/ UCC"
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --z 0 --collective all_to_allv
         echo "PARAM-Comms Pt2pt w/ UCC"
-        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --pt2pt one2one
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --pt2pt one2one --src-ranks 0 --dst-ranks 1

--- a/test/torch_pt2pt_test.py
+++ b/test/torch_pt2pt_test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+import numpy as np
+from torch_ucc_test_setup import *
+
+args = parse_test_args()
+pg = init_process_groups(args.backend, args.use_cuda)
+
+comm_size = dist.get_world_size()
+comm_rank = dist.get_rank()
+
+counts = 2 ** np.arange(24)
+print_test_head("Point-to-point", comm_rank)
+
+for count in counts:
+    tensor_ucc = get_tensor(count, args.use_cuda)
+    tensor_test = tensor_ucc.clone()
+    tensor_ucc = do_compute(tensor_ucc)
+    tensor_test = do_compute(tensor_test)
+    # pt2pt-based bcast if more than 2 processes
+    if comm_rank == 0:
+        for dst in range(comm_size-1):
+            dist.send(tensor_ucc, dst=dst+1, tag=0)
+            dist.send(tensor_test, dst=dst+1, tag=0, group=pg)
+        status = torch.tensor(1, device=tensor_ucc.device)
+    else:
+        dist.recv(tensor_ucc, src=0, tag=0)
+        dist.recv(tensor_test, src=0, tag=0, group=pg)
+        status = check_tensor_equal(tensor_ucc, tensor_test)
+    dist.all_reduce(status, group=pg)
+    print_test_result(status, count, comm_rank, comm_size)
+
+if comm_rank == 0:
+    print("Test Point-to-point: succeeded")


### PR DESCRIPTION
Summary:
- fix pt2pt enqueue: add ProgressEntry to WorkUCC
- fix deadlock at exit: do extra `ucp_worker_progress` to ensure all remote eps are closed properly
- fix deadlock in progress_loop
  - progress both UCP and UCC to avoid hang when posting mix of pt2pt and collectives
- add simple pt2pt CI test

Thanks @Sergei-Lebedev for the fix!

Differential Revision: D31156468

