### PR TITLE
override getBackendName from ProcessGroup interface

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -93,6 +93,8 @@ namespace c10d {
 #define SAVE_TENSORS(_TENSORS, _DATA) (_DATA) = (_TENSORS);
 #endif
 
+constexpr const char* UCC_BACKEND_NAME = "UCC";
+
 enum torch_ucx_tag_type_t { TORCH_UCX_P2P_TAG, TORCH_UCX_OOB_TAG };
 
 struct event_pool_t {
@@ -189,6 +191,10 @@ class ProcessGroupUCC : public ProcessGroup {
   void initComm(c10::Device dev);
 
   ~ProcessGroupUCC() override;
+
+  const std::string getBackendName() const override {
+      return std::string(UCC_BACKEND_NAME);
+  }
 
   c10::intrusive_ptr<ProcessGroup::Work> collective_post(
       OpType opType,


### PR DESCRIPTION
Summary: According to https://github.com/pytorch/pytorch/pull/64943, `getBackendName` will be a pure virtual function that all subclasses have to override, this patch overrides `getBackendName` in ProcessGroupUCC and returns "UCC"

Differential Revision: D31213298

