### PR TITLE
add env. variable to enable checking ucc/ucx errors

### DIFF
--- a/include/torch_ucc_comm.hpp
+++ b/include/torch_ucc_comm.hpp
@@ -56,7 +56,11 @@ namespace c10d {
           "(",                            \
           ucc_status_string(result),      \
           ")");                           \
-      TORCH_CHECK(false, err);            \
+      if (logger->use_critical_check) {   \
+        TORCH_CHECK(false, err);          \
+      } else {                            \
+        LOG(ERROR) << err;                \
+      }                                   \
     }                                     \
   } while (0)
 
@@ -78,7 +82,11 @@ namespace c10d {
           "(",                            \
           ucs_status_string(result),      \
           ")");                           \
-      TORCH_CHECK(false, err);            \
+      if (logger->use_critical_check) {   \
+        TORCH_CHECK(false, err);          \
+      } else {                            \
+        LOG(ERROR) << err;                \
+      }                                   \
     }                                     \
   } while (0)
 
@@ -101,7 +109,7 @@ const std::map<torch_ucc_phase_t, std::string> ucc_phase_map = {
 class TORCH_API ProcessGroupUCCLogger : public torch::CustomClassHolder {
  public:
   ProcessGroupUCCLogger();
-  ProcessGroupUCCLogger(std::string log_prefix);
+  ProcessGroupUCCLogger(std::string log_prefix_, bool use_critical_check_);
 
   std::string getLogPrefix();
   void setLogPrefix(std::string log_prefix);
@@ -117,6 +125,8 @@ class TORCH_API ProcessGroupUCCLogger : public torch::CustomClassHolder {
     LOG(ERROR) << getLogPrefix() << "[" << ucc_phase_map.at(phase) << "]"
                << "[ERROR] " << msg;
   }
+
+  bool use_critical_check = false;
 protected:
   std::string log_prefix;
 };

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -66,6 +66,7 @@ struct torch_ucc_config_t {
   std::array<bool, 32> blocking_wait;
   bool enable_profiling;
   bool use_future;
+  bool use_critical_check;
 } torch_ucc_config;
 
 void read_confg() {
@@ -102,6 +103,11 @@ void read_confg() {
   env = std::getenv("TORCH_UCC_PROFILING_ENABLE");
   if (env) {
     torch_ucc_config.enable_profiling = std::atoi(env);
+  }
+  torch_ucc_config.use_critical_check = false;
+  env = std::getenv("TORCH_UCC_USE_CHECK");
+  if (env) {
+    torch_ucc_config.use_critical_check = std::atoi(env);
   }
 }
 
@@ -581,8 +587,11 @@ ProcessGroupUCC::ProcessGroupUCC(
   uint32_t pg_id = (id++ % TORCH_UCX_COMM_BITS);
 
   logger = c10::make_intrusive<ProcessGroupUCCLogger>(
-      c10::str("[Rank ", rank_, "]", "[ProcessGroupUCC-", pg_id, "]"));
-  logger->logInfo(TORCH_UCC_INIT, "Successfully read and set ProcessGroupUCC env. variables");
+      c10::str("[Rank ", rank_, "]", "[ProcessGroupUCC-", pg_id, "]"),
+      torch_ucc_config.use_critical_check);
+  logger->logInfo(
+      TORCH_UCC_INIT,
+      "Successfully read and set ProcessGroupUCC env. variables");
   // TODO: print log of all env. variables and their values
 }
 

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -205,10 +205,11 @@ void ProcessGroupUCCLogger::setLogPrefix(std::string log_prefix_) {
 ProcessGroupUCCLogger::ProcessGroupUCCLogger() {
   setLogPrefix("[ProcessGroupUCC]");
 }
-ProcessGroupUCCLogger::ProcessGroupUCCLogger(std::string log_prefix) {
+ProcessGroupUCCLogger::ProcessGroupUCCLogger(
+    std::string log_prefix,
+    bool use_critical_check_)
+    : use_critical_check(use_critical_check_) {
   setLogPrefix(log_prefix);
 }
-
-
 
 } // namespace c10d


### PR DESCRIPTION
Summary:
add env. variable to enable/disable checking ucc/ucx errors
  - use `TORCH_UCC_USE_CHECK=1` to enable checking ucc status at critical path (default is 0)

Differential Revision: D31934896

