### PR TITLE
implement result interface in WorkUCC

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,8 @@ jobs:
         export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucc/lib:$LD_LIBRARY_PATH
         /opt/ucx/bin/ucx_info -e -u t
         export UCX_LOG_LEVEL=info
+        echo "UCC basic functionality test"
+        /bin/bash ./test/start_test.sh ./test/torch_work_test.py --backend=gloo
         echo "UCC barrier"
         /bin/bash ./test/start_test.sh ./test/torch_barrier_test.py --backend=gloo
         echo "UCC alltoall"

--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -174,6 +174,7 @@ class ProcessGroupUCC : public ProcessGroup {
     bool isSuccess() const override;
     bool wait(std::chrono::milliseconds timeout = kUnsetTimeout) override;
     c10::intrusive_ptr<c10::ivalue::Future> getFuture() override;
+    std::vector<at::Tensor> result() override;
 #ifdef USE_CUDA
     std::unique_ptr<at::cuda::CUDAEvent> fence = nullptr;
     event_pool_t* ep = nullptr;
@@ -183,6 +184,8 @@ class ProcessGroupUCC : public ProcessGroup {
    private:
     // The future returned by getFuture.
     c10::intrusive_ptr<at::ivalue::Future> future_;
+    // Store a reference to collective's outputs, used by result
+    std::shared_ptr<std::vector<at::Tensor>> outputs_;
   };
 
 

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -183,6 +183,10 @@ c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupUCC::WorkUCC::getFuture() {
   return future_;
 }
 
+std::vector<at::Tensor> ProcessGroupUCC::WorkUCC::result() {
+  return *outputs_;
+}
+
 void ProcessGroupUCC::ProgressEntry::finalize(std::exception_ptr eptr) {
   ucc_status_t status = UCC_OK;
 
@@ -634,6 +638,9 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::collective_post(
   auto work =
       c10::make_intrusive<ProcessGroupUCC::WorkUCC>(
           opType, torch_ucc_config.enable_profiling ? prof_title : nullptr);
+
+  // Store references to outputs to be used by result
+  work->outputs_ = std::make_shared<std::vector<at::Tensor>>(outputTensors);
 
   switch (dev.type()) {
     case c10::DeviceType::CPU: {

--- a/test/torch_work_test.py
+++ b/test/torch_work_test.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021.
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from torch_ucc_test_setup import *
+
+def test_future(obj):
+    print("Test WorkUCC: succeeded")
+
+args = parse_test_args()
+pg = init_process_groups(args.backend, args.use_cuda)
+
+comm_size = dist.get_world_size()
+comm_rank = dist.get_rank()
+
+print_test_head("WorkUCC", comm_rank)
+count=32
+tensor_ucc = get_tensor(count, args.use_cuda)
+
+work = dist.all_reduce(tensor_ucc, async_op=True)
+
+# test future functionality
+fut = work.get_future().then(test_future)
+
+# test result functionality
+work.wait()
+opTensor = work.result()
+
+# test future functionality
+fut.wait()


### PR DESCRIPTION
Summary:
- implement result interface in WorkUCC, which return the result/output tensor(s)
- add CI test to test basic functionalities such as future and result

Differential Revision: D32213374

