### PR TITLE
Lower case UCC

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -93,7 +93,7 @@ namespace c10d {
 #define SAVE_TENSORS(_TENSORS, _DATA) (_DATA) = (_TENSORS);
 #endif
 
-constexpr const char* UCC_BACKEND_NAME = "UCC";
+constexpr const char* UCC_BACKEND_NAME = "ucc";
 
 enum torch_ucx_tag_type_t { TORCH_UCX_P2P_TAG, TORCH_UCX_OOB_TAG };
 


### PR DESCRIPTION
Summary: Case sensitive tests need everything to be the same case. For consistency across c10d, making this lower case.

Differential Revision: D32296890

