### PR TITLE
fix collective_post default arg

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -221,8 +221,7 @@ class ProcessGroupUCC : public ProcessGroup {
 // if the event is null, then a record will be started on this
 // device
 #ifdef USE_CUDA
-    , std::unique_ptr<at::cuda::CUDAEvent> cuda_ev
-        = std::unique_ptr<at::cuda::CUDAEvent>()
+    , std::unique_ptr<at::cuda::CUDAEvent> cuda_ev = nullptr
 #endif
 	);
 


### PR DESCRIPTION
Summary: fix default value of cuda_ev in collective_post to nullptr

Differential Revision: D32384606

