### PR TITLE
improve error message in consensus protocol

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -32,47 +32,6 @@ namespace c10d {
 
 #define TORCH_UCC_DEVICE_NOT_SET -2
 
-#define TORCH_UCX_MAKE_P2P_TAG(_tag, _rank, _comm)       \
-  ((((uint64_t)(_tag)) << TORCH_UCX_TAG_BITS_OFFSET) |   \
-   (((uint64_t)(_rank)) << TORCH_UCX_RANK_BITS_OFFSET) | \
-   (((uint64_t)(_comm)) << TORCH_UCX_COMM_BITS_OFFSET))
-
-#define TORCH_UCX_MAKE_OOB_TAG(_tag, _rank, _comm)       \
-  ((((uint64_t)(_tag)) << TORCH_UCX_OOB_BITS_OFFSET) |   \
-   (((uint64_t)(_rank)) << TORCH_UCX_RANK_BITS_OFFSET) | \
-   (((uint64_t)(_rank)) << TORCH_UCX_COMM_BITS_OFFSET))
-
-#define TORCH_UCX_MAKE_SEND_TAG(_ucp_tag, _tag, _rank, _comm)      \
-  do {                                                             \
-    (_ucp_tag) = TORCH_UCX_MAKE_P2P_TAG((_tag), (_rank), (_comm)); \
-  } while (0)
-
-#define TORCH_UCX_ANY_SOURCE (TORCH_UCX_MAX_RANK - 1)
-#define TORCH_UCX_ANY_SOURCE_MASK (~TORCH_UCX_RANK_MASK)
-#define TORCH_UCX_SPECIFIC_SOURCE_MASK ((uint64_t)-1)
-
-#define TORCH_UCX_MAKE_RECV_TAG(_ucp_tag, _ucp_tag_mask, _tag, _rank, _comm) \
-  do {                                                                       \
-    (_ucp_tag) = TORCH_UCX_MAKE_P2P_TAG((_tag), (_rank), (_comm));           \
-    if ((_rank) == TORCH_UCX_ANY_SOURCE) {                                   \
-      (_ucp_tag_mask) = TORCH_UCX_ANY_SOURCE_MASK;                           \
-    } else {                                                                 \
-      (_ucp_tag_mask) = TORCH_UCX_SPECIFIC_SOURCE_MASK;                      \
-    }                                                                        \
-  } while (0)
-
-#define TORCH_UCX_MAKE_OOB_SEND_TAG(_ucp_tag, _tag, _rank, _comm)  \
-  do {                                                             \
-    (_ucp_tag) = TORCH_UCX_MAKE_OOB_TAG((_tag), (_rank), (_comm)); \
-  } while (0)
-
-#define TORCH_UCX_MAKE_OOB_RECV_TAG(                               \
-    _ucp_tag, _ucp_tag_mask, _tag, _rank, _comm)                   \
-  do {                                                             \
-    (_ucp_tag) = TORCH_UCX_MAKE_OOB_TAG((_tag), (_rank), (_comm)); \
-    (_ucp_tag_mask) = (uint64_t)-1;                                \
-  } while (0)
-
 #ifdef USE_CUDA
 #define SAVE_TENSORS(_TENSORS, _DATA)                       \
   do {                                                      \
@@ -145,15 +104,21 @@ class ProcessGroupUCC : public ProcessGroup {
   public:
     ProgressEntry(
         CommBase* comm,
-        ucc_coll_req_h request)
-        : status_(UCC_INPROGRESS), comm_(comm), request_(request) {}
+        ucc_coll_req_h request,
+        uint64_t seq_num)
+        : status_(UCC_INPROGRESS), comm_(comm), request_(request),
+          seq_num_(seq_num) {}
     void finalize(std::exception_ptr eptr = nullptr);
     ucc_status_t status_;
     CommBase* comm_;
     ucc_coll_req_h request_;
+    uint64_t seq_num_;
     std::unique_ptr<WorkData> data;
     c10::intrusive_ptr<c10::ivalue::Future> future_;
     std::exception_ptr eptr_;
+    std::vector<ucp_ep_h> *eps;
+    int rank;
+    int comm_id;
   };
 
   class WorkUCC : public ProcessGroup::Work {
@@ -311,9 +276,11 @@ template <typename PreProcess, typename PostProcess>
 
 class CommPG {
   c10::intrusive_ptr<ProcessGroupUCCLogger> logger;
+  std::vector<torch_ucc_rank_state_t> comm_state;
   std::shared_ptr<torch_ucc_oob_coll_info_t> oob;
   CommUCX ucx_comm;
   CommUCC ucc_comm;
+  uint64_t seq_num;
   c10::DeviceIndex device_index;
   std::mutex mutex;
   std::thread progress_thread;
@@ -323,6 +290,8 @@ class CommPG {
   bool stop_progress_loop;
   bool collective_inprogress;
 
+  void check_communicator_status(int my_rank, int comm_id, uint64_t seq_num,
+      std::vector<ucp_ep_h> *eps);
  public:
   c10::DeviceIndex cuda_device_index;
   CommPG(const c10::intrusive_ptr<ProcessGroupUCCLogger>& logger,
@@ -355,14 +324,21 @@ class CommPG {
       c10::intrusive_ptr<ProcessGroupUCC::WorkUCC> work,
       ucc_coll_args_t& coll,
       ucc_team_h team,
-      ucc_ee_h ee);
+      ucc_ee_h ee,
+      std::vector<ucp_ep_h> *eps,
+      int rank,
+      int comm_id);
+
 #endif
 
   void enqueue_collective(
       std::unique_ptr<ProcessGroupUCC::WorkData> data,
       c10::intrusive_ptr<ProcessGroupUCC::WorkUCC> work,
       ucc_coll_args_t& coll,
-      ucc_team_h team);
+      ucc_team_h team,
+      std::vector<ucp_ep_h> *eps,
+      int rank,
+      int comm_id);
 
   static std::shared_ptr<CommPG> get_comm(
       uint32_t& id,
@@ -385,6 +361,13 @@ class CommPG {
       size_t size,
       ucp_tag_t ucp_tag,
       ucp_tag_t ucp_tag_mask);
+  friend ucs_status_t torch_ucc_timeout_am_cb(
+      void *arg,
+      const void *header,
+      size_t header_length,
+      void *data,
+      size_t length,
+      const ucp_am_recv_param_t *param);
 };
 
 } // namespace c10d

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ if with_cuda is None or with_cuda == "no":
     )
 else:
     print("CUDA support is enabled")
+    plugin_libraries.append("cuda")
     plugin_compile_args.append("-DUSE_CUDA")
     module = cpp_extension.CUDAExtension(
         name = "torch_ucc",

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -72,6 +72,7 @@ struct torch_ucc_config_t {
   std::array<bool, 32> blocking_wait;
   bool enable_profiling;
   bool use_future;
+  int comm_state_check_timeout;
   bool shared_comm;
   bool use_allgatherv;
 } torch_ucc_config;
@@ -98,6 +99,7 @@ void read_confg() {
   torch_ucc_config.use_future = true;
   torch_ucc_config.shared_comm = false;
   torch_ucc_config.use_allgatherv = false;
+  torch_ucc_config.comm_state_check_timeout = 2000;
 
   // read all torch_ucc env. variables and update the map
   char* env;
@@ -125,6 +127,8 @@ void read_confg() {
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_SHARED_COMM"));
   torch_ucc_config.use_allgatherv =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_USE_ALLGATHERV"));
+  torch_ucc_config.comm_state_check_timeout =
+      std::stoi(torch_ucc_envs_map.at("TORCH_UCC_COMM_CHECK_TIMEOUT"));
 }
 
 void check_device(c10::Device dev1, c10::Device dev2) {
@@ -237,6 +241,71 @@ void ProcessGroupUCC::ProgressEntry::finalize(std::exception_ptr eptr) {
   }
 }
 
+ucs_status_t torch_ucc_timeout_am_cb(
+    void *arg,
+    const void *header,
+    size_t header_length,
+    void *data,
+    size_t length,
+    const ucp_am_recv_param_t *param) {
+  torch_ucc_timeout_desc_t *dsc = (torch_ucc_timeout_desc_t*)header;
+  CommPG *comm = (CommPG*)arg;
+  torch_ucc_rank_state_t * state = new torch_ucc_rank_state_t;
+  ucp_request_param_t params;
+  ucp_tag_t ucp_tag;
+
+#ifdef USE_CUDA
+  if (comm->cuda_device_index >= 0) {
+    CUdevice device;
+    CUresult st;
+    unsigned int flags;
+    int active;
+    st = cuDeviceGet(&device, comm->cuda_device_index);
+    if (st != CUDA_SUCCESS) {
+      *state = TORCH_UCC_RANK_STATE_DEVICE_ERROR;
+      goto send_response;
+    }
+    st = cuDevicePrimaryCtxGetState(device, &flags, &active);
+    if (st != CUDA_SUCCESS || !active) {
+      *state = TORCH_UCC_RANK_STATE_DEVICE_ERROR;
+      goto send_response;
+    }
+  }
+#endif
+
+  *state = TORCH_UCC_RANK_STATE_COLLECTIVE_NOT_POSTED;
+  if (comm->seq_num > dsc->seq_num) {
+    *state = TORCH_UCC_RANK_STATE_COLLECTIVE_DONE;
+    for (auto& entry : comm->progress_queue) {
+      if (entry->seq_num_ == dsc->seq_num) {
+        switch (entry->request_->status)
+        {
+        case UCC_ERR_TIMED_OUT:
+          *state = TORCH_UCC_RANK_STATE_COLLECTIVE_TIMEOUT;
+          break;
+        default:
+          *state = TORCH_UCC_RANK_STATE_COLLECTIVE_INPROGRESS;
+        }
+        break;
+      }
+    }
+  }
+
+send_response:
+  TORCH_UCX_MAKE_OOB_SEND_TAG(ucp_tag, 0, dsc->rank, dec->comm_id);
+  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+      UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_USER_DATA;
+  params.datatype = ucp_dt_make_contig(sizeof(torch_ucc_rank_state_t));
+  params.user_data = (void*)state;
+  params.cb.send = [](void* request, ucs_status_t status, void* user_data) {
+    torch_ucc_rank_state_t * state = (torch_ucc_rank_state_t*)user_data;
+    delete user_data;
+    ucp_request_free(request);
+  };
+  ucp_tag_send_nbx(param->reply_ep, state, 1, ucp_tag, &params);
+  return UCS_OK;
+}
+
 CommPG::CommPG(
     const c10::intrusive_ptr<ProcessGroupUCCLogger>& logger_,
     std::shared_ptr<torch_ucc_oob_coll_info_t> oob_,
@@ -245,10 +314,20 @@ CommPG::CommPG(
       oob(oob_),
       ucx_comm(oob->size, logger),
       ucc_comm(oob, logger),
+      seq_num(0),
       cuda_device_index(TORCH_UCC_DEVICE_NOT_SET) {
   if (dev.is_cuda()) {
     cuda_device_index = dev.index();
   }
+
+  ucp_am_handler_param_t params;
+  params.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
+      UCP_AM_HANDLER_PARAM_FIELD_CB | UCP_AM_HANDLER_PARAM_FIELD_ARG;
+  params.id = TORCH_UCC_TIMEOUT_AM_ID;
+  params.cb = torch_ucc_timeout_am_cb;
+  params.arg = this;
+
+  ucx_comm.set_am_recv_handler(&params);
   stop_progress_loop = false;
   collective_inprogress = false;
   progress_thread = std::thread(&CommPG::progress_loop, this);
@@ -503,8 +582,8 @@ c10::intrusive_ptr<ProcessGroup::Work> CommPG::enqueue_p2p(
     }
     return work;
   }
-  auto entry =
-      std::make_shared<ProcessGroupUCC::ProgressEntry>(&ucx_comm, request);
+  auto entry = std::make_shared<ProcessGroupUCC::ProgressEntry>(
+      &ucx_comm, request, 0);
   work->entry_ = entry;
   std::unique_lock<std::mutex> lock(mutex);
   progress_queue.push_back(entry);
@@ -517,16 +596,22 @@ void CommPG::enqueue_collective(
     std::unique_ptr<ProcessGroupUCC::WorkData> data,
     c10::intrusive_ptr<ProcessGroupUCC::WorkUCC> work,
     ucc_coll_args_t& coll,
-    ucc_team_h team) {
+    ucc_team_h team,
+    std::vector<ucp_ep_h> *eps,
+    int rank,
+    int comm_id) {
   ucc_coll_req_h request;
   TORCH_UCC_CHECK(
       ucc_collective_init(&coll, &request, team), "failed to init collective");
   TORCH_UCC_CHECK(ucc_collective_post(request), "failed to post collective");
 
   auto entry =
-      std::make_shared<ProcessGroupUCC::ProgressEntry>(&ucc_comm, request);
+      std::make_shared<ProcessGroupUCC::ProgressEntry>(&ucc_comm, request, seq_num++);
   entry->data = std::move(data);
   entry->future_ = work->getFuture();
+  entry->eps = eps;
+  entry->rank = rank;
+  entry->comm_id = comm_id;
   work->entry_ = entry;
   std::unique_lock<std::mutex> lock(mutex);
   progress_queue.push_back(entry);
@@ -540,7 +625,10 @@ void CommPG::enqueue_cuda_collective(
     c10::intrusive_ptr<ProcessGroupUCC::WorkUCC> work,
     ucc_coll_args_t& coll,
     ucc_team_h team,
-    ucc_ee_h ee) {
+    ucc_ee_h ee,
+    std::vector<ucp_ep_h> *eps,
+    int rank,
+    int comm_id) {
   ucc_coll_req_h request;
   TORCH_UCC_CHECK(
       ucc_collective_init(&coll, &request, team),
@@ -557,8 +645,11 @@ void CommPG::enqueue_cuda_collective(
   TORCH_CHECK(st == UCC_OK && post_ev->ev_type == UCC_EVENT_COLLECTIVE_POST);
   ucc_ee_ack_event(ee, post_ev);
   auto entry =
-      std::make_shared<ProcessGroupUCC::ProgressEntry>(&ucc_comm, request);
+      std::make_shared<ProcessGroupUCC::ProgressEntry>(&ucc_comm, request, seq_num++);
   entry->data = std::move(data);
+  entry->eps = eps;
+  entry->rank = rank;
+  entry->comm_id = comm_id;
   work->entry_ = entry;
   std::unique_lock<std::mutex> lock(mutex);
   progress_queue.push_back(entry);
@@ -567,6 +658,86 @@ void CommPG::enqueue_cuda_collective(
 }
 #endif
 
+void CommPG::check_communicator_status(
+      int my_rank,
+      int comm_id,
+      uint64_t seq_num,
+      std::vector<ucp_ep_h> *eps) {
+  ucp_request_param_t params_am, params_recv;
+  torch_ucc_timeout_desc_t dsc;
+
+  comm_state.resize(eps->size());
+  params_am.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_FLAGS;
+  params_am.flags = UCP_AM_SEND_REPLY;
+  params_am.cb.send = [](void* request, ucs_status_t status, void* user_data) {
+    static_cast<ucc_coll_req_h>(request)->status = UCC_OK;
+  };
+  dsc.seq_num = seq_num;
+  dsc.comm_id = comm_id;
+  for (auto i = 0; i < (int)eps->size(); i++) {
+    if (i == my_rank) {
+      comm_state[i] = TORCH_UCC_RANK_STATE_COLLECTIVE_TIMEOUT;
+      continue;
+    }
+    comm_state[i] = TORCH_UCC_RANK_STATE_NOT_RESPONDIG;
+    dsc.rank = i;
+    ucp_am_send_nbx((*eps)[i], TORCH_UCC_TIMEOUT_AM_ID, &dsc, sizeof(dsc),
+                    nullptr, 0ul, &params_am);
+    ucp_tag_t ucp_tag, ucp_tag_mask;
+    TORCH_UCX_MAKE_OOB_RECV_TAG(ucp_tag, ucp_tag_mask, 0, i, dsc.comm_id);
+    params_recv.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+      UCP_OP_ATTR_FIELD_DATATYPE;
+    params_recv.datatype = ucp_dt_make_contig(sizeof(torch_ucc_rank_state_t));
+    params_recv.cb.recv = [](void* request,
+                             ucs_status_t status,
+                             const ucp_tag_recv_info_t* info,
+                             void* user_data) {
+      ucp_request_free(request);
+    };
+    ucp_tag_recv_nbx(ucx_comm.worker, &(comm_state[i]), 1, ucp_tag, ucp_tag_mask,
+                     &params_recv);
+  }
+  auto start = std::chrono::system_clock::now();
+  auto end = std::chrono::system_clock::now();
+  while (std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() <=
+         torch_ucc_config.comm_state_check_timeout)
+  {
+    end = std::chrono::system_clock::now();
+    ucx_comm.progress();
+  }
+  std::map<torch_ucc_rank_state_t, std::vector<int> > state_res_;
+  for (auto i = 0; i < (int)eps->size(); i++) {
+    if (comm_state[i] != TORCH_UCC_RANK_STATE_COLLECTIVE_DONE) {
+      std::string err_log = c10::str(
+        "on rank ",
+        std::to_string(i),
+        ": ",
+        torch_ucc_rank_state_string(comm_state[i])
+      );
+      TORCH_UCC_LOG_ERROR(TORCH_UCC_COMM_CHECK, err_log);
+      if (comm_state[i] > TORCH_UCC_RANK_STATE_COLLECTIVE_DONE ||
+          comm_state[i] < TORCH_UCC_RANK_STATE_NOT_RESPONDIG) {
+        comm_state[i] = TORCH_UCC_RANK_STATE_UNKNOWN;
+      }
+    }
+    if (state_res_.find(comm_state[i]) == state_res_.end()) {
+        state_res_[comm_state[i]] = {i};
+    } else {
+        state_res_[comm_state[i]].push_back(i);
+    }
+  }
+  for (auto sr : state_res_) {
+    if (sr.first != TORCH_UCC_RANK_STATE_COLLECTIVE_DONE && sr.second.size() > 0) {
+      TORCH_UCC_LOG_ERROR(
+          TORCH_UCC_COMM_CHECK,
+          c10::str("Ranks are : ", torch_ucc_rank_state_string(sr.first),
+          " (", sr.first, "): ", sr.second));
+     }
+   }
+  TORCH_CHECK(false, c10::str(logger->getLogPrefix(),
+      "Aborting...some ranks might have issues as shown above"));
+}
+
 void CommPG::progress_loop() {
   std::unique_lock<std::mutex> lock(mutex);
 #ifdef USE_CUDA
@@ -574,12 +745,13 @@ void CommPG::progress_loop() {
 #endif
   while (!stop_progress_loop) {
     if (progress_queue.empty()) {
-      queue_produce_cv.wait(lock);
+      queue_produce_cv.wait_for(lock, std::chrono::milliseconds(500));
+      ucc_comm.progress();
+      ucx_comm.progress();
       continue;
     }
     collective_inprogress = true;
     auto work = progress_queue.front();
-    progress_queue.pop_front();
     lock.unlock();
 #ifdef USE_CUDA
     if ((!device_set) && (cuda_device_index != TORCH_UCC_DEVICE_NOT_SET)) {
@@ -605,11 +777,16 @@ void CommPG::progress_loop() {
     } catch (...) {
       eptr = std::current_exception();
     }
+    if (work->request_->status == UCC_ERR_TIMED_OUT) {
+      check_communicator_status(work->rank, work->comm_id, work->seq_num_,
+        work->eps);
+    }
     work->finalize(eptr);
     work = nullptr;
     collective_inprogress = false;
     queue_consume_cv.notify_one();
     lock.lock();
+    progress_queue.pop_front();
   }
 }
 
@@ -721,7 +898,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::collective_post(
         work->future_ = c10::make_intrusive<at::ivalue::Future>(
             c10::ListType::create(c10::TensorType::get()));
       }
-      comm->enqueue_collective(std::move(data), work, coll, team);
+      comm->enqueue_collective(std::move(data), work, coll, team, &eps, rank_,
+        comm_id);
       return work;
     }
 #ifdef USE_CUDA
@@ -731,7 +909,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::collective_post(
       cuda_ev->block(*stream);
       at::cuda::CUDAStreamGuard guard(*stream);
       preproc();
-      comm->enqueue_cuda_collective(std::move(data), work, coll, team, cuda_ee);
+      comm->enqueue_cuda_collective(std::move(data), work, coll, team, cuda_ee,
+                                    &eps, rank_, comm_id);
       postproc();
       cuda_ev->record(*stream);
       work->fence = std::move(cuda_ev);

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -18,7 +18,9 @@ const char *torch_ucc_rank_state_string(torch_ucc_rank_state_t state)
     case TORCH_UCC_RANK_STATE_NOT_RESPONDIG:
         return "Not responding";
     case TORCH_UCC_RANK_STATE_COLLECTIVE_NOT_POSTED:
-        return "Collective wasn't posted";
+        return "Collective wasn't initalized nor posted";
+    case TORCH_UCC_RANK_STATE_COLLECTIVE_INIT:
+        return "Collective initialized, but not yet posted";
     case TORCH_UCC_RANK_STATE_COLLECTIVE_INPROGRESS:
         return "Collective posted and in progress";
     case TORCH_UCC_RANK_STATE_COLLECTIVE_TIMEOUT:


### PR DESCRIPTION
Summary:

- `comm_state` -> `comm_snapshot`
  - keep a snapshot of seq_num, optype and state from all ranks
- split `check_communicator_status()` into two parts
  1. set up active messages to collect comms snapshot from other ranks
  2. `comms_status_health_check`: check if any ranks are at bad state or lagging behind based on `comm_snapshot` collected in step-1 (including the rank itself)
- do `check_communicator_status()` when the progres queue is empty for too long (same timeout period from the ProcessGroupUCC)
- progress thread prints potential problematic ranks and comms snapshot when aborting the job to help triage

example output:
```
terminate called after throwing an instance of 'c10::Error'
 what():  [Rank 1][ProcessGroupUCC-1][COMM_CHECK]
	Aborting comms #12 (op=ALLTOALL_BASE) due to the problematic ranks: [ 0 ]
		Ranks [0] are 'Collective wasn't posted'
	Comms status of other ranks: 
		Ranks [0] are last known progressing comms #11 (op=ALLTOALL_BASE)
		Ranks [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15] are last known progressing comms #12 (op=ALLTOALL_BASE)
Exception raised from comms_status_health_check at third-party/torch_ucc/src/torch_ucc.cpp:777 (most recent call first):
# 3  c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 4  c10d::CommPG::comms_status_health_check(int, int)
# 5  c10d::CommPG::check_communicator_status(std::shared_ptr<c10d::ProcessGroupUCC::ProgressEntry>)
# 6  c10d::CommPG::progress_loop()
# 7  execute_native_thread_routine
# 8  start_thread
# 9  clone
```

Reviewed By: srinivas212

Differential Revision: D32543522

