### PR TITLE
[WIP] Add PyTorch unit tests.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,3 +91,10 @@ jobs:
         echo "PARAM-Comms Pt2pt w/ UCC"
         export TORCH_UCC_TEST_SIZE=2
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --pt2pt one2one --src-ranks 0 --dst-ranks 1
+    - name: PyTorch distributed tests
+      run: |
+        git_version=$(python -c 'import torch; print(torch.version.git_version)')
+        git clone https://github.com/pytorch/pytorch.git
+        cd pytorch
+        git checkout ${git_version}
+        python test/run_test.py --verbose -i distributed/test_distributed_spawn

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,7 +94,9 @@ jobs:
     - name: PyTorch distributed tests
       run: |
         git_version=$(python -c 'import torch; print(torch.version.git_version)')
+        pip3 install expecttest
         git clone https://github.com/pytorch/pytorch.git
         cd pytorch
         git checkout ${git_version}
+        python -c "import torch.distributed as dist; print(dist.is_nccl_available())"
         python test/run_test.py --verbose -i distributed/test_distributed_spawn

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
         apt-get update
         apt-get install -y --no-install-recommends build-essential git cmake libtool-bin wget autoconf automake
         conda uninstall -y pytorch torchvision
-        pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
     - name: Get UCX
       run: |
         git clone ${OPENUCX_LINK} /tmp/ucx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,6 +95,7 @@ jobs:
       run: |
         set -e
         git_version=$(python -c 'import torch; print(torch.version.git_version)')
+        torch_ucc_file=$(python -c "import inspect; import torch; import torch_ucc; print(inspect.getfile(torch_ucc))")
         python -c "import torch.distributed as dist; assert dist.is_nccl_available()"
         pip3 install expecttest
         git clone https://github.com/pytorch/pytorch.git

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,7 +95,7 @@ jobs:
       run: |
         set -e
         git_version=$(python -c 'import torch; print(torch.version.git_version)')
-        torch_ucc_file=$(python -c "import inspect; import torch; import torch_ucc; print(inspect.getfile(torch_ucc))")
+        export TORCH_UCC_LIBRARY_PATH=$(python -c "import inspect; import torch; import torch_ucc; print(inspect.getfile(torch_ucc))")
         python -c "import torch.distributed as dist; assert dist.is_nccl_available()"
         pip3 install expecttest
         git clone https://github.com/pytorch/pytorch.git

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,9 +94,9 @@ jobs:
     - name: PyTorch distributed tests
       run: |
         git_version=$(python -c 'import torch; print(torch.version.git_version)')
+        python -c "import torch.distributed as dist; print(dist.is_nccl_available())"
         pip3 install expecttest
         git clone https://github.com/pytorch/pytorch.git
         cd pytorch
         git checkout ${git_version}
-        python -c "import torch.distributed as dist; print(dist.is_nccl_available())"
         python test/run_test.py --verbose -i distributed/test_distributed_spawn

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,10 +93,11 @@ jobs:
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --pt2pt one2one --src-ranks 0 --dst-ranks 1
     - name: PyTorch distributed tests
       run: |
+        set -e
         git_version=$(python -c 'import torch; print(torch.version.git_version)')
-        python -c "import torch.distributed as dist; print(dist.is_nccl_available())"
+        python -c "import torch.distributed as dist; assert dist.is_nccl_available()"
         pip3 install expecttest
         git clone https://github.com/pytorch/pytorch.git
         cd pytorch
         git checkout ${git_version}
-        python test/run_test.py --verbose -i distributed/test_distributed_spawn
+        python test/run_test.py --verbose --nccl -i distributed/test_distributed_spawn


### PR DESCRIPTION
This PR runs PyTorch's unit tests in torch_ucc's CI. Right now, PyTorch's unit tests don't contain many beneficial tests for torch_ucc, but in the long term, I will incrementally enable more and more PyTorch's unit tests on the UCC process group, and eventually, I want torch_ucc to have a test coverage as large as other process groups like NCCL, Gloo, MPI, etc. That means all PyTorch's unit tests that run on NCCL, Gloo, or MPI should run on UCC as well.

**NOTE: This PR doesn't work standalone. PyTorch changes are needed, and still WIP**

TODO:
- [x] Set the `TORCH_UCC_LIBRARY_PATH` environment variable
- [x] Selectively run only "NCCL" tests