### PR TITLE
check for ucx mt support

### DIFF
--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -60,7 +60,9 @@ const std::map<ReduceOp, ucc_reduction_op_t> ucc_op_map = {
     {ReduceOp::BAND, UCC_OP_BAND},
     {ReduceOp::BOR, UCC_OP_BOR},
     {ReduceOp::BXOR, UCC_OP_BXOR},
+#if TORCH_VERSION_MAJOR > 1 || (TORCH_VERSION_MAJOR == 1 && TORCH_VERSION_MINOR >= 11)
     {ReduceOp::AVG, UCC_OP_AVG},
+#endif
 };
 
 struct torch_ucc_config_t {

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -20,7 +20,15 @@ CommUCX::CommUCX(
   ucp_config_t* config;
   ucs_status_t st;
   ucp_worker_params_t worker_params;
+  ucp_lib_attr_t ucp_attr;
 
+  ucp_attr.field_mask = UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL;
+  TORCH_UCX_CHECK(
+      ucp_lib_query(&ucp_attr), "failed to query UCP lib attributes");
+  TORCH_CHECK(
+      ucp_attr.max_thread_level == UCS_THREAD_MODE_MULTI,
+      "ucx library wasn't initialized with multithreading support, "
+      "please check ucx build options");
   TORCH_UCX_CHECK(
       ucp_config_read("TORCH", nullptr, &config), "failed to read UCP config");
 
@@ -174,7 +182,8 @@ CommUCC::CommUCC(
       ucc_lib_get_attr(lib, &lib_attr), "failed to query for lib attr");
   TORCH_CHECK(
       lib_attr.thread_mode == UCC_THREAD_MULTIPLE,
-      "ucc library wasn't initialized with mt support, please check ucc compile options ");
+      "ucc library wasn't initialized with multithreading support, "
+      "please check ucc build options");
   st = ucc_context_config_read(lib, NULL, &context_config);
   if (st != UCC_OK) {
     // FIXME: would this cause deadlock if only one rank fails?


### PR DESCRIPTION
1. Check UCX and UCC libraries support multithreading, throw exception if not
2. Disable AVG reduce operation for pytorch 1.10