### PR TITLE
enable alltoall primitive

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -123,10 +123,10 @@ class ProcessGroupUCC : public ProcessGroup {
           send_offsets(size),
           recv_lengths(size),
           recv_offsets(size) {}
-    std::vector<uint32_t> send_lengths;
-    std::vector<uint32_t> send_offsets;
-    std::vector<uint32_t> recv_lengths;
-    std::vector<uint32_t> recv_offsets;
+    std::vector<uint64_t> send_lengths;
+    std::vector<uint64_t> send_offsets;
+    std::vector<uint64_t> recv_lengths;
+    std::vector<uint64_t> recv_offsets;
   };
 
   class AllgathervWorkData : public WorkData {

--- a/test/torch_alltoall_test.py
+++ b/test/torch_alltoall_test.py
@@ -8,6 +8,7 @@
 #
 
 from torch_ucc_test_setup import *
+import numpy as np
 
 args = parse_test_args()
 pg = init_process_groups(args.backend, args.use_cuda)
@@ -15,22 +16,31 @@ pg = init_process_groups(args.backend, args.use_cuda)
 comm_size = dist.get_world_size()
 comm_rank = dist.get_rank()
 
-counts = [comm_size]
-for i in range(20):
-    counts.append(counts[-1] * 2)
+counts = 2 ** np.arange(4, 22)
 
 print_test_head("Alltoall", comm_rank)
 for count in counts:
-    recv_tensor_ucc = get_tensor(count, args.use_cuda)
-    recv_tensor_test = get_tensor(count, is_cuda=False)
-    send_tensor = get_tensor(count, args.use_cuda)
-    send_tensor = do_compute(send_tensor)
-    req = dist.all_to_all_single(recv_tensor_ucc, send_tensor, async_op=True)
-    req.wait()
-    dist.all_to_all_single(recv_tensor_test, send_tensor.cpu(), group=pg)
-    status = check_tensor_equal(recv_tensor_ucc, recv_tensor_test)
+    recv_tensor_test = get_tensor(count * comm_size, is_cuda=False)
+    send_tensor_list = []
+    recv_tensor_ucc = []
+    for p in range(comm_size):
+        recv_tensor_ucc.append(get_tensor(count, args.use_cuda))
+        send_tensor_list.append(get_tensor(count, args.use_cuda))
+
+    dist.all_to_all(
+        recv_tensor_ucc,
+        send_tensor_list,
+    )
+    # flatten the send_tensor_list and use all_to_all_single as not all PGs support all_to_all primitive
+    dist.all_to_all_single(
+        recv_tensor_test, torch.stack(send_tensor_list, dim=0).view(-1).cpu(), group=pg
+    )
+
+    status = check_tensor_equal(
+        torch.stack(recv_tensor_ucc, dim=0).view(-1), recv_tensor_test
+    )
     dist.all_reduce(status, group=pg)
-    print_test_result(status, count, comm_rank, comm_size)
+    print_test_result(status, "{} x {}".format(count, comm_size), comm_rank, comm_size)
 
 if comm_rank == 0:
     print("Test alltoall: succeeded")


### PR DESCRIPTION
Summary: enable alltoall primitive, which takes a list of tensors for input and another list of tensors for output. We use Alltoallv in UCC to avoid flattening the tensors.

Differential Revision: D35159293

