### PR TITLE
test: refactor check funcs to support different mem type in ucc and pg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+select = B,C,E,F,P,T4,W,B9
+max-line-length = 120
+# C408 ignored because we like the dict keyword argument syntax
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    # shebang has extra meaning in fbcode lints, so I think it's not worth trying
+    # to line this up with executable bit
+    EXE001,
+    # these ignores are from flake8-bugbear; please fix!
+    B007,B008,
+    # these ignores are from flake8-comprehensions; please fix!
+    C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415,
+    # bare 'except': ignored by fbcode lints; please fix!
+    B001,E722,
+    # import *: ignored by fbcode lints; please fix!
+    F403
+per-file-ignores = __init__.py: F401 torch/utils/cpp_extension.py: B950
+optional-ascii-coding = True

--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -1,0 +1,9 @@
+flake8==3.8.2
+flake8-bugbear==20.1.4
+flake8-comprehensions==3.3.0
+flake8-executable==2.0.4
+git+https://github.com/malfet/flake8-coding.git
+flake8-pyi==20.5.0
+mccabe==0.6.1
+pycodestyle==2.6.0
+pyflakes==2.2.0

--- a/test/blocking_wait_test.py
+++ b/test/blocking_wait_test.py
@@ -7,71 +7,80 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import argparse
 import os
 import sys
-import argparse
+
 import torch
 import torch.distributed as dist
-import torch_ucc
+
+# torch_ucc is required to enable ucc PG
+import torch_ucc  # noqa: F401
 
 def init_pg(backend):
-  global comm_rank, comm_size
-  try:
-    comm_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-    comm_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
-    local_rank = int(os.environ['OMPI_COMM_WORLD_LOCAL_RANK'])
-  except:
-    print('OMPI env variables are not found')
-    sys.exit(1)
-  torch.cuda.set_device(local_rank)
+    global comm_rank, comm_size
+    try:
+        comm_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+        comm_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+        local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+    except:
+        print("OMPI env variables are not found")
+        sys.exit(1)
+    torch.cuda.set_device(local_rank)
 
-  os.environ['MASTER_PORT'] = '32167'
-  os.environ['MASTER_ADDR'] = 'localhost'
-  os.environ['RANK']        = str(comm_rank)
-  os.environ['WORLD_SIZE']  = str(comm_size)
-  dist.init_process_group(backend, rank=comm_rank, world_size=comm_size)
+    os.environ["MASTER_PORT"] = "32167"
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["RANK"] = str(comm_rank)
+    os.environ["WORLD_SIZE"] = str(comm_size)
+    dist.init_process_group(backend, rank=comm_rank, world_size=comm_size)
+
 
 def allreduce_test():
-  global comm_rank, comm_size
-  num_iters = 10
-  dev = torch.device('cuda')
-  t = torch.ones(100, device=dev)
-  for i in range(10):
-    dist.all_reduce(t)
-  if torch.all(torch.eq(t, comm_size**num_iters)):
-    print(f"Rank {comm_rank}: success")
-  else:
-    print(f"Rank {comm_rank}: failed")
+    global comm_rank, comm_size
+    num_iters = 10
+    dev = torch.device("cuda")
+    t = torch.ones(100, device=dev)
+    for i in range(10):
+        dist.all_reduce(t)
+    if torch.all(torch.eq(t, comm_size ** num_iters)):
+        print(f"Rank {comm_rank}: success")
+    else:
+        print(f"Rank {comm_rank}: failed")
+
 
 def alltoall_test():
-  global comm_rank, comm_size
-  dev = torch.device('cuda')
-  t_send = torch.zeros(comm_size, device=dev) + comm_rank
-  t_recv = torch.zeros(comm_size, device=dev)
-  dist.all_to_all_single(t_recv, t_send)
-  t_recv = t_recv + 1
-  dist.all_reduce(t_recv)
-  if torch.all(torch.eq(t_recv, comm_size*torch.arange(start=1, end=comm_size+1, device=dev))):
-    print(f"Rank {comm_rank}: success")
-  else:
-    print(f"Rank {comm_rank}: failed")
+    global comm_rank, comm_size
+    dev = torch.device("cuda")
+    t_send = torch.zeros(comm_size, device=dev) + comm_rank
+    t_recv = torch.zeros(comm_size, device=dev)
+    dist.all_to_all_single(t_recv, t_send)
+    t_recv = t_recv + 1
+    dist.all_reduce(t_recv)
+    if torch.all(
+        torch.eq(
+            t_recv, comm_size * torch.arange(start=1, end=comm_size + 1, device=dev)
+        )
+    ):
+        print(f"Rank {comm_rank}: success")
+    else:
+        print(f"Rank {comm_rank}: failed")
 
 
 if __name__ == "__main__":
-  if not torch.cuda.is_available():
-    print("cuda is not available")
-    sys.exit(1)
-  parser = argparse.ArgumentParser(description="PG UCC nonblocking test")
-  parser.add_argument("--backend", type=str, default='ucc')
-  parser.add_argument("--test", type=str, default='ucc')
-  args = parser.parse_args()
+    if not torch.cuda.is_available():
+        print("cuda is not available")
+        sys.exit(1)
+    parser = argparse.ArgumentParser(description="PG UCC nonblocking test")
+    parser.add_argument("--backend", type=str, default="ucc")
+    parser.add_argument("--test", type=str, default="ucc")
+    args = parser.parse_args()
 
-  comm_rank = -1
-  comm_size = -1
-  init_pg(args.backend)
-  if args.test == "allreduce":
-    allreduce_test()
-  elif args.test == "alltoall":
-    alltoall_test()
-  else:
-    print("Wrong test name")
+    comm_rank = -1
+    comm_size = -1
+    init_pg(args.backend)
+    if args.test == "allreduce":
+        allreduce_test()
+    elif args.test == "alltoall":
+        alltoall_test()
+    else:
+        print("Wrong test name")

--- a/test/torch_allgather_test.py
+++ b/test/torch_allgather_test.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import sys
+
 import numpy as np
 from torch_ucc_test_setup import *
 
@@ -24,8 +24,8 @@ for count in counts:
     tensors_out_ucc = []
     tensors_out_test = []
     for p in range(comm_size):
-        tensors_out_ucc.append(get_tensor(count, args.use_cuda));
-        tensors_out_test.append(get_tensor(count, args.use_cuda));
+        tensors_out_ucc.append(get_tensor(count, args.use_cuda))
+        tensors_out_test.append(get_tensor(count, args.use_cuda))
     dist.all_gather(tensors_out_ucc, tensor_input)
     dist.all_gather(tensors_out_test, tensor_input, group=pg)
     status = check_tensor_list_equal(tensors_out_ucc, tensors_out_test)

--- a/test/torch_alltoall_bench.py
+++ b/test/torch_alltoall_bench.py
@@ -64,7 +64,7 @@ if args.backend == "nccl" and not args.use_cuda:
     sys.exit(0)
 
 if args.use_cuda:
-    #    torch.cuda.set_device(comm_rank)
+    torch.cuda.set_device(comm_rank)
     args.device = torch.device("cuda")
 else:
     args.device = torch.device("cpu")
@@ -96,7 +96,7 @@ while size <= args.max_size:
         if i > args.skip:
             time += finish - start
     time = [time / args.iter]
-    if args.backend == "nccl":
+    if args.use_cuda:
         max_time = torch.tensor([time], device=args.device)
         min_time = torch.tensor([time], device=args.device)
         avg_time = torch.tensor([time], device=args.device)

--- a/test/torch_alltoall_bench.py
+++ b/test/torch_alltoall_bench.py
@@ -8,67 +8,72 @@
 #
 
 import argparse
+import os
+import sys
+from time import perf_counter
+
 import torch
 import torch.distributed as dist
-import sys
-import os
-from time import perf_counter
-import torch_ucc
+
+# torch_ucc is required to enable ucc PG
+import torch_ucc  # noqa: F401
+
 
 def get_tensor(size, device, val):
-    count = size//4
+    count = size // 4
     t = torch.ones([count], dtype=torch.int32, device=device)
     t = t + val
     return t
 
+
 parser = argparse.ArgumentParser(description="Process Group Alltoall Benchmark")
-parser.add_argument("--backend", type=str, default='mpi')
-parser.add_argument("--use-cuda", default=False, action='store_true')
-parser.add_argument("--min-size", type=int, default=2**5)
-parser.add_argument("--max-size", type=int, default=2**15)
+parser.add_argument("--backend", type=str, default="mpi")
+parser.add_argument("--use-cuda", default=False, action="store_true")
+parser.add_argument("--min-size", type=int, default=2 ** 5)
+parser.add_argument("--max-size", type=int, default=2 ** 15)
 parser.add_argument("--skip", type=int, default=500)
 parser.add_argument("--iter", type=int, default=100)
 args = parser.parse_args()
 
 try:
-    comm_size  = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-    comm_rank  = int(os.environ['OMPI_COMM_WORLD_RANK'])
+    comm_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+    comm_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
 except:
     try:
-        comm_size = int(os.environ['WORLD_SIZE'])
-        comm_rank = int(os.environ['RANK'])
+        comm_size = int(os.environ["WORLD_SIZE"])
+        comm_rank = int(os.environ["RANK"])
     except:
-        print('OMPI env variables are not found')
+        print("OMPI env variables are not found")
         sys.exit(1)
 
-if not os.environ.get('MASTER_PORT', None):
-    os.environ['MASTER_PORT'] = '32167'
-if not os.environ.get('MASTER_ADDR', None):
-    os.environ['MASTER_ADDR'] = 'localhost'
-if not os.environ.get('RANK', None):
-    os.environ['RANK'] = str(comm_rank)
-if not os.environ.get('WORLD_SIZE', None):
-    os.environ['WORLD_SIZE'] = str(comm_size)
+if not os.environ.get("MASTER_PORT", None):
+    os.environ["MASTER_PORT"] = "32167"
+if not os.environ.get("MASTER_ADDR", None):
+    os.environ["MASTER_ADDR"] = "localhost"
+if not os.environ.get("RANK", None):
+    os.environ["RANK"] = str(comm_rank)
+if not os.environ.get("WORLD_SIZE", None):
+    os.environ["WORLD_SIZE"] = str(comm_size)
 
 if args.use_cuda and not torch.cuda.is_available():
     print("CUDA is not available")
     sys.exit(0)
 
-if args.backend=='nccl' and not args.use_cuda:
+if args.backend == "nccl" and not args.use_cuda:
     print("NCCL backend doesn't support host buffers")
     sys.exit(0)
 
 if args.use_cuda:
-#    torch.cuda.set_device(comm_rank)
-    args.device = torch.device('cuda')
+    #    torch.cuda.set_device(comm_rank)
+    args.device = torch.device("cuda")
 else:
-    args.device = torch.device('cpu')
+    args.device = torch.device("cpu")
 
 if comm_rank == 0:
     print("World size {}".format(comm_size))
-    print("%-10s %-10s %-10s %-10s" %('size', 'min, us', 'avg, us', 'max, us'))
+    print("%-10s %-10s %-10s %-10s" % ("size", "min, us", "avg, us", "max, us"))
 
-if args.backend != 'mpi':
+if args.backend != "mpi":
     dist.init_process_group(args.backend, rank=comm_rank, world_size=comm_size)
 else:
     dist.init_process_group(args.backend)
@@ -82,16 +87,16 @@ while size <= args.max_size:
     for i in range(args.iter + args.skip):
         start = perf_counter()
         req = dist.all_to_all_single(recv_tensor, send_tensor, async_op=True)
-        #req = dist.all_reduce(send_tensor, op=dist.ReduceOp.SUM, async_op=True)
+        # req = dist.all_reduce(send_tensor, op=dist.ReduceOp.SUM, async_op=True)
         req.wait()
-        if args.backend == 'nccl':
+        if args.backend == "nccl":
             torch.cuda.synchronize(args.device)
         finish = perf_counter()
         dist.barrier()
-        if  i > args.skip:
+        if i > args.skip:
             time += finish - start
     time = [time / args.iter]
-    if args.backend == 'nccl':
+    if args.backend == "nccl":
         max_time = torch.tensor([time], device=args.device)
         min_time = torch.tensor([time], device=args.device)
         avg_time = torch.tensor([time], device=args.device)
@@ -104,5 +109,13 @@ while size <= args.max_size:
     dist.all_reduce(min_time, op=dist.ReduceOp.MIN)
     dist.all_reduce(avg_time, op=dist.ReduceOp.SUM)
     if comm_rank == 0:
-        print("%-10i %-10.3f %-10.3f %-10.3f" %(size, min_time[0] * (10**6), avg_time[0] * (10**6)/comm_size, max_time[0] * (10**6)))
+        print(
+            "%-10i %-10.3f %-10.3f %-10.3f"
+            % (
+                size,
+                min_time[0] * (10 ** 6),
+                avg_time[0] * (10 ** 6) / comm_size,
+                max_time[0] * (10 ** 6),
+            )
+        )
     size = size * 2

--- a/test/torch_alltoall_test.py
+++ b/test/torch_alltoall_test.py
@@ -7,7 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import time
 from torch_ucc_test_setup import *
 
 args = parse_test_args()
@@ -26,7 +25,7 @@ for count in counts:
     recv_tensor_test = get_tensor(count, args.use_cuda)
     send_tensor = get_tensor(count, args.use_cuda)
     send_tensor = do_compute(send_tensor)
-    req = dist.all_to_all_single(recv_tensor_ucc, send_tensor, async_op = True)
+    req = dist.all_to_all_single(recv_tensor_ucc, send_tensor, async_op=True)
     req.wait()
     dist.all_to_all_single(recv_tensor_test, send_tensor, group=pg)
     status = check_tensor_equal(recv_tensor_ucc, recv_tensor_test)

--- a/test/torch_alltoallv_test.py
+++ b/test/torch_alltoallv_test.py
@@ -8,7 +8,6 @@
 #
 
 from torch_ucc_test_setup import *
-import torch.autograd.profiler as profiler
 import numpy as np
 
 args = parse_test_args()
@@ -23,22 +22,29 @@ print_test_head("Alltoallv", comm_rank)
 for count in counts:
     np.random.seed(3131)
 
-    split = np.random.randint(low=1, high=2*count//comm_size, size=(comm_size,comm_size))
+    split = np.random.randint(
+        low=1, high=2 * count // comm_size, size=(comm_size, comm_size)
+    )
     input_size = np.sum(split, axis=1)
     output_size = np.sum(split, axis=0)
 
     send_tensor = get_tensor(input_size[comm_rank], args.use_cuda)
     recv_tensor = get_tensor(output_size[comm_rank], args.use_cuda)
     recv_tensor_test = get_tensor(output_size[comm_rank], args.use_cuda)
-    dist.all_to_all_single(recv_tensor, send_tensor,
-                          split[:, comm_rank],
-                          split[comm_rank, :])
-    dist.all_to_all_single(recv_tensor_test, send_tensor,
-                          split[:, comm_rank],
-                          split[comm_rank, :],
-                          group=pg)
+    dist.all_to_all_single(
+        recv_tensor, send_tensor, split[:, comm_rank], split[comm_rank, :]
+    )
+    dist.all_to_all_single(
+        recv_tensor_test,
+        send_tensor,
+        split[:, comm_rank],
+        split[comm_rank, :],
+        group=pg,
+    )
     status = check_tensor_equal(recv_tensor, recv_tensor_test)
     dist.all_reduce(status, group=pg)
-    print_test_result(status, "{}({})".format(count, input_size[comm_rank]), comm_rank, comm_size)
+    print_test_result(
+        status, "{}({})".format(count, input_size[comm_rank]), comm_rank, comm_size
+    )
 if comm_rank == 0:
     print("Test alltoallv: succeeded")

--- a/test/torch_barrier_test.py
+++ b/test/torch_barrier_test.py
@@ -7,9 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import time
-import sys
 import random
+import sys
+import time
 from torch_ucc_test_setup import *
 
 args = parse_test_args()
@@ -20,7 +20,7 @@ comm_rank = dist.get_rank()
 
 for i in range(comm_size):
     rand_sleep = random.randint(1, 1000)
-    time.sleep(rand_sleep/1000)
+    time.sleep(rand_sleep / 1000)
     if i == comm_rank:
         print("rank {} checks in".format(comm_rank))
         sys.stdout.flush()

--- a/test/torch_init_test.py
+++ b/test/torch_init_test.py
@@ -7,24 +7,26 @@
 
 import os
 import random
-import torch
-import torch.distributed as dist
-import torch_ucc
-import time
 import sys
+import time
 
-comm_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-comm_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+import torch.distributed as dist
 
-os.environ['MASTER_PORT'] = '32167'
-os.environ['MASTER_ADDR'] = 'localhost'
-os.environ['RANK']        = str(comm_rank)
-os.environ['WORLD_SIZE']  = str(comm_size)
-dist.init_process_group('ucc', rank=comm_rank, world_size=comm_size)
-#dist.new_group(ranks=[0, 1], backend='ucc')
+# torch_ucc is required to enable ucc PG
+import torch_ucc  # noqa: F401
+
+comm_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+comm_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+
+os.environ["MASTER_PORT"] = "32167"
+os.environ["MASTER_ADDR"] = "localhost"
+os.environ["RANK"] = str(comm_rank)
+os.environ["WORLD_SIZE"] = str(comm_size)
+dist.init_process_group("ucc", rank=comm_rank, world_size=comm_size)
+# dist.new_group(ranks=[0, 1], backend='ucc')
 for i in range(comm_size):
     rand_sleep = random.randint(1, 1000)
-    time.sleep(rand_sleep/1000)
+    time.sleep(rand_sleep / 1000)
     if i == comm_rank:
         print("rank {} checks in".format(comm_rank))
         sys.stdout.flush()

--- a/test/torch_multiple_comms_test.py
+++ b/test/torch_multiple_comms_test.py
@@ -1,4 +1,3 @@
-import os
 from torch_ucc_test_setup import *
 
 # create 2 UCC PGs

--- a/test/torch_pg_ucc_test.py
+++ b/test/torch_pg_ucc_test.py
@@ -7,30 +7,30 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import argparse
 import os
 import sys
-import argparse
+
 import torch
 import torch.distributed as dist
-import torch_ucc
 
 parser = argparse.ArgumentParser(description="Process Group UCC test")
-parser.add_argument("--backend", type=str, default='mpi')
-parser.add_argument("--op", type=str, default='p2p')
+parser.add_argument("--backend", type=str, default="mpi")
+parser.add_argument("--op", type=str, default="p2p")
 parser.add_argument("--use-cuda", type=bool, default=False)
 args = parser.parse_args()
 
 try:
-    size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-    rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+    size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+    rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
 except:
-    print('OMPI env variables are not found')
+    print("OMPI env variables are not found")
     sys.exit(1)
 
-os.environ['MASTER_PORT'] = '32167'
-os.environ['MASTER_ADDR'] = 'localhost'
-os.environ['RANK']        = str(rank)
-os.environ['WORLD_SIZE']  = str(size)
+os.environ["MASTER_PORT"] = "32167"
+os.environ["MASTER_ADDR"] = "localhost"
+os.environ["RANK"] = str(rank)
+os.environ["WORLD_SIZE"] = str(size)
 
 
 torch.cuda.set_device(rank)
@@ -62,8 +62,8 @@ elif args.op == "reduce":
 elif args.op == "alltoall":
     dist.all_to_all_single(t2, t)
 elif args.op == "alltoallv":
-    out_split =[1]*size
-    in_split = [1]*size
+    out_split = [1] * size
+    in_split = [1] * size
     dist.all_to_all_single(t2, t, out_split, in_split)
 elif args.op == "allgather":
     dist.all_gather([t1, t2], t)
@@ -72,6 +72,6 @@ else:
     print("Incorrect operation")
     sys.exit(1)
 
-#dist.barrier()
-print('rank ', rank, ':', t, ":", t1, ":", t2)
+# dist.barrier()
+print("rank ", rank, ":", t, ":", t1, ":", t2)
 dist.destroy_process_group()

--- a/test/torch_pt2pt_test.py
+++ b/test/torch_pt2pt_test.py
@@ -24,9 +24,9 @@ for count in counts:
     tensor_test = do_compute(tensor_test)
     # pt2pt-based bcast if more than 2 processes
     if comm_rank == 0:
-        for dst in range(comm_size-1):
-            dist.send(tensor_ucc, dst=dst+1, tag=0)
-            dist.send(tensor_test, dst=dst+1, tag=0, group=pg)
+        for dst in range(comm_size - 1):
+            dist.send(tensor_ucc, dst=dst + 1, tag=0)
+            dist.send(tensor_test, dst=dst + 1, tag=0, group=pg)
         status = torch.tensor(1, device=tensor_ucc.device)
     else:
         dist.recv(tensor_ucc, src=0, tag=0)

--- a/test/torch_pt2pt_test.py
+++ b/test/torch_pt2pt_test.py
@@ -27,7 +27,7 @@ for count in counts:
         for dst in range(comm_size - 1):
             dist.send(tensor_ucc, dst=dst + 1, tag=0)
             dist.send(tensor_test, dst=dst + 1, tag=0, group=pg)
-        status = torch.tensor(1, device=tensor_ucc.device)
+        status = torch.tensor(1, device=tensor_test.device)
     else:
         dist.recv(tensor_ucc, src=0, tag=0)
         dist.recv(tensor_test, src=0, tag=0, group=pg)

--- a/test/torch_reduce_scatter_test.py
+++ b/test/torch_reduce_scatter_test.py
@@ -21,7 +21,7 @@ print_test_head("Reduce_scatter", comm_rank)
 for count in counts:
     tensors_input = []
     for p in range(comm_size):
-        tensors_input.append(get_tensor(count, args.use_cuda));
+        tensors_input.append(get_tensor(count, args.use_cuda))
     tensor_ucc = get_tensor(count, args.use_cuda)
     tensor_test = tensor_ucc.clone()
     tensors_input[0] = do_compute(tensors_input[0])

--- a/test/torch_sendrecv_test.py
+++ b/test/torch_sendrecv_test.py
@@ -6,29 +6,33 @@
 #
 
 import os
+import sys
+
 import torch
 import torch.distributed as dist
-import torch_ucc
 
-comm_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-comm_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+# torch_ucc is required to enable ucc PG
+import torch_ucc  # noqa: F401
+
+comm_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+comm_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
 
 if comm_size != 2:
-  print("sendrecv rest requires exactly 2 ranks")
-  sys.exit(0)
+    print("sendrecv rest requires exactly 2 ranks")
+    sys.exit(0)
 
-os.environ['MASTER_PORT'] = '32167'
-os.environ['MASTER_ADDR'] = 'localhost'
-os.environ['RANK']        = str(comm_rank)
-os.environ['WORLD_SIZE']  = str(comm_size)
-dist.init_process_group('ucc', rank=comm_rank, world_size=comm_size)
+os.environ["MASTER_PORT"] = "32167"
+os.environ["MASTER_ADDR"] = "localhost"
+os.environ["RANK"] = str(comm_rank)
+os.environ["WORLD_SIZE"] = str(comm_size)
+dist.init_process_group("ucc", rank=comm_rank, world_size=comm_size)
 
 if comm_rank == 0:
-  t = torch.full([16], comm_rank + 1)
-  print("send: ", t)
-  dist.send(t, 1, tag=128)
+    t = torch.full([16], comm_rank + 1)
+    print("send: ", t)
+    dist.send(t, 1, tag=128)
 if comm_rank == 1:
-  t = torch.full([16], 0)
-  print("recv before: ", t)
-  dist.recv(t, 0, tag=128)
-  print("recv after: ", t)
+    t = torch.full([16], 0)
+    print("recv before: ", t)
+    dist.recv(t, 0, tag=128)
+    print("recv after: ", t)

--- a/test/torch_timeout_test.py
+++ b/test/torch_timeout_test.py
@@ -7,9 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import time
 import sys
-import random
+import time
 from torch_ucc_test_setup import *
 from datetime import timedelta
 
@@ -21,17 +20,17 @@ comm_rank = dist.get_rank()
 
 dist.barrier()
 if comm_rank == 0:
-  time.sleep(20)
+    time.sleep(20)
 
 estr = ""
 try:
-  req = dist.barrier()
+    req = dist.barrier()
 except Exception as e:
-  estr = str(e)
+    estr = str(e)
 
 if comm_rank != 0:
-  if "Timeout expired" in estr:
-    print("Test OK")
-  else:
-    print("Test Failed")
-    sys.exit(1)
+    if "Timeout expired" in estr:
+        print("Test OK")
+    else:
+        print("Test Failed")
+        sys.exit(1)

--- a/test/torch_ucc_test_setup.py
+++ b/test/torch_ucc_test_setup.py
@@ -61,20 +61,24 @@ def init_process_groups(bend, use_cuda, to=timedelta(seconds=60)):
     return pg
 
 
-def check_tensor_equal(t1, t2):
-    if torch.all(torch.eq(t1, t2)):
-        return torch.tensor(1, device=t1.device)
+# Compare UCC result tensor with the checking PG's result tensor.
+# Return check status allocated on PG's device because the result is exchanged by PG
+def check_tensor_equal(t_ucc, t_pg):
+    if torch.all(torch.eq(t_ucc, t_pg)):
+        return torch.tensor(1, device=t_pg.device)
     else:
         print("failed on rank {}".format(os.environ["RANK"]))
-        return torch.tensor(0, device=t1.device)
+        return torch.tensor(0, device=t_pg.device)
 
 
-def check_tensor_list_equal(t1, t2):
-    num_tensors = len(t1)
+# Compare UCC result tensor list with the checking PG's result tensor list.
+# Return check status allocated on PG's device because the result is exchanged by PG
+def check_tensor_list_equal(t_ucc, t_pg):
+    num_tensors = len(t_ucc)
     for i in range(num_tensors):
-        if not torch.all(torch.eq(t1[i], t2[i])):
-            return torch.tensor(0, device=t1[i].device)
-    return torch.tensor(1, device=t1[i].device)
+        if not torch.all(torch.eq(t_ucc[i], t_pg[i])):
+            return torch.tensor(0, device=t_pg[i].device)
+    return torch.tensor(1, device=t_pg[i].device)
 
 
 def print_test_head(test_name, comm_rank):

--- a/test/torch_ucc_test_setup.py
+++ b/test/torch_ucc_test_setup.py
@@ -8,78 +8,88 @@
 #
 
 import argparse
-import torch
-import torch.distributed as dist
-import torch_ucc
-import sys
 import os
+import sys
 from datetime import timedelta
 
+import torch
+import torch.distributed as dist
+
+# torch_ucc is required to enable ucc PG
+import torch_ucc  # noqa: F401
+
+
 def parse_test_args():
-  parser = argparse.ArgumentParser(description="PG UCC Test")
-  parser.add_argument("--backend", type=str, default='mpi')
-  parser.add_argument("--use-cuda", default=False, action='store_true')
-  parser.add_argument("--enable-prof",default=False, action='store_true')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="PG UCC Test")
+    parser.add_argument("--backend", type=str, default="mpi")
+    parser.add_argument("--use-cuda", default=False, action="store_true")
+    parser.add_argument("--enable-prof", default=False, action="store_true")
+    args = parser.parse_args()
 
-  if args.use_cuda and not torch.cuda.is_available():
-    print("CUDA is not available")
-    sys.exit(0)
+    if args.use_cuda and not torch.cuda.is_available():
+        print("CUDA is not available")
+        sys.exit(0)
 
-  return args
+    return args
 
 
 def get_tensor(count, is_cuda):
-  dev = torch.device('cuda') if is_cuda else torch.device('cpu')
-  t = torch.randint(0, 100, (count,), dtype=torch.int, device=dev)
-  return t
+    dev = torch.device("cuda") if is_cuda else torch.device("cpu")
+    t = torch.randint(0, 100, (count,), dtype=torch.int, device=dev)
+    return t
+
 
 def init_process_groups(bend, use_cuda, to=timedelta(seconds=60)):
-  try:
-    comm_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-    comm_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
-    local_rank = int(os.environ['OMPI_COMM_WORLD_LOCAL_RANK'])
-  except:
-    print('OMPI env variables are not found')
-    sys.exit(1)
+    try:
+        comm_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+        comm_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+        local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+    except:
+        print("OMPI env variables are not found")
+        sys.exit(1)
 
-  if use_cuda:
-    torch.cuda.set_device(local_rank)
+    if use_cuda:
+        torch.cuda.set_device(local_rank)
 
-  os.environ['MASTER_PORT'] = '32167'
-  os.environ['MASTER_ADDR'] = 'localhost'
-  os.environ['RANK']        = str(comm_rank)
-  os.environ['WORLD_SIZE']  = str(comm_size)
-  dist.init_process_group('ucc', rank=comm_rank, world_size=comm_size, timeout=to)
-  pg = dist.new_group(backend=bend)
+    os.environ["MASTER_PORT"] = "32167"
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["RANK"] = str(comm_rank)
+    os.environ["WORLD_SIZE"] = str(comm_size)
+    dist.init_process_group("ucc", rank=comm_rank, world_size=comm_size, timeout=to)
+    pg = dist.new_group(backend=bend)
 
-  return pg
+    return pg
+
 
 def check_tensor_equal(t1, t2):
-  if torch.all(torch.eq(t1, t2)):
-    return torch.tensor(1, device=t1.device)
-  else:
-    print("failed on rank {}".format(os.environ['RANK']))
-    return torch.tensor(0, device=t1.device)
+    if torch.all(torch.eq(t1, t2)):
+        return torch.tensor(1, device=t1.device)
+    else:
+        print("failed on rank {}".format(os.environ["RANK"]))
+        return torch.tensor(0, device=t1.device)
+
 
 def check_tensor_list_equal(t1, t2):
-  num_tensors = len(t1)
-  for i in range(num_tensors):
-    if not torch.all(torch.eq(t1[i], t2[i])):
-      return torch.tensor(0, device=t1[i].device)
-  return torch.tensor(1, device=t1[i].device)
+    num_tensors = len(t1)
+    for i in range(num_tensors):
+        if not torch.all(torch.eq(t1[i], t2[i])):
+            return torch.tensor(0, device=t1[i].device)
+    return torch.tensor(1, device=t1[i].device)
+
 
 def print_test_head(test_name, comm_rank):
-  if comm_rank == 0:
-    print("{} test".format(test_name))
-    print("{0:20} {1}".format("count", "result"))
+    if comm_rank == 0:
+        print("{} test".format(test_name))
+        print("{0:20} {1}".format("count", "result"))
+
 
 def print_test_result(status, count, comm_rank, comm_size):
-  if comm_rank == 0:
-    result = "OK" if status == comm_size else "Failed"
-    print("{0:20} {1}".format(str(count), result))
-  if status != comm_size:
-    sys.exit(1)
+    if comm_rank == 0:
+        result = "OK" if status == comm_size else "Failed"
+        print("{0:20} {1}".format(str(count), result))
+    if status != comm_size:
+        sys.exit(1)
+
 
 def do_compute(t):
-  return torch.topk(t, t.size()[0])[0]
+    return torch.topk(t, t.size()[0])[0]

--- a/test/torch_work_test.py
+++ b/test/torch_work_test.py
@@ -9,8 +9,10 @@
 
 from torch_ucc_test_setup import *
 
+
 def test_future(obj):
     print("Test WorkUCC: succeeded")
+
 
 args = parse_test_args()
 pg = init_process_groups(args.backend, args.use_cuda)
@@ -19,7 +21,7 @@ comm_size = dist.get_world_size()
 comm_rank = dist.get_rank()
 
 print_test_head("WorkUCC", comm_rank)
-count=32
+count = 32
 tensor_ucc = get_tensor(count, args.use_cuda)
 
 work = dist.all_reduce(tensor_ucc, async_op=True)


### PR DESCRIPTION
Summary:
The check functions in tests assume both ucc and the checking pg use the same mem type. However, we will need to statically set the pg's mem type to CPU in case the ucc's mem type is not supported by pg. For instance, ucc supports AMD GPU (cuda device w/ hipified pytorch) which is not supported by any other backend.

In order to change pg's mem type, we need first refactor the check functions:
1. Explicitly set first input tensor is from UCC and the second is from PG. This will allow simpler mem type conversion & check. Note that such an assumption is already true in all tests, so no impact to tests.
2. The returned check status is allocated from PG' device rather than UCC. This change makes sense because the check status is always exchanged by PG in all tests. It was not a problem in current code because PG and UCC always use the same device.

PG's mem type change will be addressed in the next commit.

Differential Revision: D35296058

