### PR TITLE
Support all non-overlapping and dense tensors

### DIFF
--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -135,9 +135,9 @@ void check_tensor(const std::vector<at::Tensor>& tensors) {
   if (tensors.size() != 1) {
     throw std::runtime_error("ProcessGroupUCC takes 1 tensor");
   }
-  if (!tensors[0].is_contiguous()) {
+  if (!tensors[0].is_non_overlapping_and_dense()) {
     throw std::runtime_error(
-        "ProcessGroupUCC input tensor has to be contiguous");
+        "ProcessGroupUCC input tensor has to be dense and non-overlapping");
   }
   if (tensors[0].is_sparse()) {
     throw std::runtime_error("ProcessGroupUCC input tensor has to be dense");


### PR DESCRIPTION
I don't see any reason why a tensor must be contiguous. This would make it impossible for tasks like NHWC training. A better constrain would be `is_non_overlapping_and_dense`, like in:
https://github.com/pytorch/pytorch/blob/f6c275f55ddfd22f8c0558efad3068b0e91f1560/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1290
https://github.com/pytorch/pytorch/blob/f6c275f55ddfd22f8c0558efad3068b0e91f1560/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1260

See also: https://github.com/pytorch/pytorch/pull/76142