### PR TITLE
Refactor hipify setup logic for reuse

### DIFF
--- a/hipify.py
+++ b/hipify.py
@@ -1,0 +1,31 @@
+import os
+
+from torch.utils.hipify import hipify_python
+
+CUDA_TO_HIP_MAPPINGS = [
+    ("UCS_MEMORY_TYPE_CUDA", "UCS_MEMORY_TYPE_ROCM"),
+    ("UCC_MEMORY_TYPE_CUDA", "UCC_MEMORY_TYPE_ROCM"),
+    ("UCC_EE_CUDA_STREAM", "UCC_EE_ROCM_STREAM"),
+    ("nccl", "rccl"),
+]
+
+# TorchUCC specific hipification
+def torch_ucc_hipify_file(src_path, dst_path, verbose=True):
+    if verbose:
+        print("Torch-UCC hipification applied to {} -> {}".format(src_path, dst_path))
+    with open(src_path, "rt", encoding="utf-8") as fin:
+        fin.seek(0)
+        source = fin.read()
+        for k, v in CUDA_TO_HIP_MAPPINGS:
+            source = source.replace(k, v)
+        fin.close()
+
+    with open(dst_path, "wt", encoding="utf-8") as fout:
+        fout.write(source)
+        fout.close()
+
+
+# Overwrite each source file for hipification
+def torch_ucc_hipify(src_path_list, verbose=True):
+    for src_path in src_path_list:
+        torch_ucc_hipify_file(src_path, src_path)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import sys
 from setuptools import setup
 import torch
 from torch.utils import cpp_extension
+from hipify import torch_ucc_hipify
 
 ucc_plugin_dir = os.path.dirname(os.path.abspath(__file__))
 ucx_home = os.environ.get("UCX_HOME")
@@ -59,27 +60,6 @@ if '--oss' in sys.argv:
   plugin_sources += ["src/torch_ucc_init_oss.cpp"]
 else:
   plugin_sources += ["src/torch_ucc_init.cpp"]
-
-CUDA_TO_HIP_MAPPINGS = [
-  ('UCS_MEMORY_TYPE_CUDA', 'UCS_MEMORY_TYPE_ROCM'),
-  ('UCC_MEMORY_TYPE_CUDA', 'UCC_MEMORY_TYPE_ROCM')
-]
-
-# Overwrite each source file for hipification
-def torch_ucc_hipify(src_path_list):
-  for src_path in src_path_list:
-    print("Torch-UCC hipification applied to " + src_path)
-    with open(src_path, 'rt', encoding='utf-8') as fin:
-      fin.seek(0)
-      source = fin.read()
-      for k, v in CUDA_TO_HIP_MAPPINGS:
-        source = source.replace(k, v)
-      fin.close()
-
-    with open(src_path, 'wt', encoding='utf-8') as fout:
-      fout.write(source)
-      fout.close()
-
 
 with_cuda = os.environ.get("WITH_CUDA")
 if with_cuda is None or with_cuda == "no":


### PR DESCRIPTION
Summary:
We move hipify logic in setup to a separate file for later reuse.

It adds a verbose input parameter to optionally turn off hipificaiton log. By default we enable verbose log.

It also adds two missing hipify mappings.

Differential Revision: D35943980

