### PR TITLE
add scatter and gather blocking wait options to Torch-UCC

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,6 +60,9 @@ jobs:
           /bin/bash ./test/start_test.sh ./test/torch_bcast_test.py --backend=gloo
           echo "UCC reduce"
           /bin/bash ./test/start_test.sh ./test/torch_reduce_test.py --backend=gloo
+          # FIXME: disabled as UCC does not support gather on CPU tensor yet
+          # echo "UCC gather"
+          # /bin/bash ./test/start_test.sh ./test/torch_gather_test.py --backend=gloo
         done
         echo "UCC basic functionality test"
         /bin/bash ./test/start_test.sh ./test/torch_work_test.py --backend=gloo
@@ -103,6 +106,9 @@ jobs:
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective broadcast
         echo "PARAM-Comms Allgather w/ UCC"
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_gather
+        # FIXME: disabled as UCC does not support gather on CPU tensor yet
+        # echo "PARAM-Comms Gather w/ UCC"
+        # /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective gather
         echo "PARAM-Comms Quantized Allreduce w/ UCC (use of c10d future)"
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --bitwidth 16 --collective all_reduce
         echo "PARAM-Comms Non-blocking Allreduce w/ UCC"

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -120,7 +120,9 @@ std::map<std::string, std::string> torch_ucc_envs_map = {
     {"TORCH_UCC_ALLREDUCE_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_ALLTOALL_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_BCAST_BLOCKING_WAIT", "1"},
+    {"TORCH_UCC_GATHER_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_REDUCE_SCATTER_BLOCKING_WAIT", "1"},
+    {"TORCH_UCC_SCATTER_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_USE_FUTURE", "1"},
     {"TORCH_UCC_PROFILING_ENABLE", "0"},
     {"TORCH_UCC_TLS", "nccl,ucp"},
@@ -156,6 +158,10 @@ void read_confg() {
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_BCAST_BLOCKING_WAIT"));
   torch_ucc_config.blocking_wait[(std::uint8_t)OpType::REDUCE_SCATTER] =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_REDUCE_SCATTER_BLOCKING_WAIT"));
+  torch_ucc_config.blocking_wait[(std::uint8_t)OpType::SCATTER] =
+      std::stoi(torch_ucc_envs_map.at("TORCH_UCC_SCATTER_BLOCKING_WAIT"));
+  torch_ucc_config.blocking_wait[(std::uint8_t)OpType::GATHER] =
+      std::stoi(torch_ucc_envs_map.at("TORCH_UCC_GATHER_BLOCKING_WAIT"));
   torch_ucc_config.use_future =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_USE_FUTURE"));
   torch_ucc_config.enable_profiling =

--- a/test/torch_gather_test.py
+++ b/test/torch_gather_test.py
@@ -1,0 +1,44 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021.
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+
+import numpy as np
+from torch_ucc_test_setup import *
+
+args = parse_test_args()
+pg = init_process_groups(args.backend, args.use_cuda)
+
+comm_size = dist.get_world_size()
+comm_rank = dist.get_rank()
+
+counts = 2 ** np.arange(24)
+print_test_head("Gather", comm_rank)
+for count in counts:
+    tensor_input = get_tensor(count, args.use_cuda)
+    tensors_out_ucc = None
+    tensors_out_test = None
+    if comm_rank == 0:
+        tensors_out_ucc = []
+        tensors_out_test = []
+        for p in range(comm_size):
+            tensors_out_ucc.append(get_tensor(count, args.use_cuda))
+            tensors_out_test.append(get_tensor(count, is_cuda=False))
+
+    dist.gather(gather_list=tensors_out_ucc, tensor=tensor_input, dst=0)
+    dist.gather(gather_list=tensors_out_test, tensor=tensor_input.cpu(), dst=0, group=pg)
+
+    if comm_rank == 0:
+        status = check_tensor_list_equal(tensors_out_ucc, tensors_out_test)
+    else:
+        status = torch.tensor(1, device=tensor_ucc.device)
+
+    dist.all_reduce(status, group=pg)
+    print_test_result(status, count, comm_rank, comm_size)
+if comm_rank == 0:
+    print("Test gather: succeeded")


### PR DESCRIPTION
Summary:
Enable setting `TORCH_UCC_GATHER_BLOCKING_WAIT` and `TORCH_UCC_SCATTER_BLOCKING_WAIT` to use blocking
(default) or non-blocking wait for gather and scatter operations

Reviewed By: bryanmr

Differential Revision: D36152512

