### PR TITLE
add allgather_base blocking wait option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,6 +106,8 @@ jobs:
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective broadcast
         echo "PARAM-Comms Allgather w/ UCC"
         /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_gather
+        echo "PARAM-Comms Allgather_base w/ UCC"
+        /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective all_gather_base
         # FIXME: disabled as UCC does not support gather on CPU tensor yet
         # echo "PARAM-Comms Gather w/ UCC"
         # /bin/bash ./test/start_test.sh /tmp/param/train/comms/pt/comms.py --backend ucc --device cpu --b 4 --e 4M --c 1 --collective gather

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -117,6 +117,7 @@ struct torch_ucc_config_t {
 
 std::map<std::string, std::string> torch_ucc_envs_map = {
     {"TORCH_UCC_ALLGATHER_BLOCKING_WAIT", "1"},
+    {"TORCH_UCC_ALLGATHER_BASE_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_ALLREDUCE_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_ALLTOALL_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_BCAST_BLOCKING_WAIT", "1"},
@@ -150,6 +151,8 @@ void read_confg() {
   }
   torch_ucc_config.blocking_wait[(std::uint8_t)OpType::ALLGATHER] =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_ALLGATHER_BLOCKING_WAIT"));
+  torch_ucc_config.blocking_wait[(std::uint8_t)OpType::_ALLGATHER_BASE] =
+      std::stoi(torch_ucc_envs_map.at("TORCH_UCC_ALLGATHER_BASE_BLOCKING_WAIT"));
   torch_ucc_config.blocking_wait[(std::uint8_t)OpType::ALLREDUCE] =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_ALLREDUCE_BLOCKING_WAIT"));
   torch_ucc_config.blocking_wait[(std::uint8_t)OpType::ALLTOALL_BASE] =


### PR DESCRIPTION
Summary: Enable setting `TORCH_UCC_ALLGATHER_BASE_BLOCKING_WAIT` to use non/-blocking wait for allgather_base collective

Differential Revision: D36431675

