### PR TITLE
fix health check error when multiple PGs are used

### DIFF
--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -368,7 +368,7 @@ std::shared_ptr<CommPG> CommPG::get_comm(
           logger, oob, dev, is_health_check);
       comm = shared_comm;
     } else {
-      if (dev.is_cuda()) {
+      if (dev.is_cuda() && !is_health_check) {
         if ((shared_comm->cuda_device_index != TORCH_UCC_DEVICE_NOT_SET) &&
             (shared_comm->cuda_device_index != dev.index())) {
           TORCH_UCC_LOG_ERROR(


### PR DESCRIPTION
Summary:
**WHY**
When multiple PGs are used, each process should still use the same device (application is responsible for following this guideline). In the health check process, `getCUDADeviceForRank` always picks GPU device based on global rank, and if `TORCH_UCC_SHARED_COMM=1`, then different PGs might pick up different device that results in runtime error (https://github.com/facebookresearch/torch_ucc/blob/main/src/torch_ucc.cpp#L374-L378).

**WHAT**

this patch skips assigning/checking device index when calling `CommPG::get_comms` if shared communicator is enabled, so that if the follow-up shared communicator would still use the same device for health check (rather than making wrong assumption).

Differential Revision: D36605093

