### PR TITLE
generate comms trace for post-analysis and replay

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -151,7 +151,7 @@ class ProcessGroupUCC : public ProcessGroup {
     friend class ProcessGroupUCC;
     friend class CommPG;
 
-  public:
+   public:
     ProgressEntry(
         CommBase* comm,
         ucc_coll_req_h request)
@@ -174,6 +174,11 @@ class ProcessGroupUCC : public ProcessGroup {
         OpType opType,
         const char* prof_title)
         : ProcessGroup::Work(-1, opType, prof_title) {}
+    WorkUCC(
+        OpType opType,
+        const char* prof_title,
+        const c10::intrusive_ptr<ProcessGroupUCCLogger>& logger)
+        : ProcessGroup::Work(-1, opType, prof_title), logger_(logger) {}
     ~WorkUCC();
     void setException();
     void setAndThrowException();
@@ -188,13 +193,14 @@ class ProcessGroupUCC : public ProcessGroup {
 #endif
    protected:
     std::shared_ptr<ProgressEntry> entry_;
+    c10::intrusive_ptr<ProcessGroupUCCLogger> logger_;
+
    private:
     // The future returned by getFuture.
     c10::intrusive_ptr<at::ivalue::Future> future_;
     // Store a reference to collective's outputs, used by result
     std::shared_ptr<std::vector<at::Tensor>> outputs_;
   };
-
 
   explicit ProcessGroupUCC(
       const c10::intrusive_ptr<Store>& store,
@@ -229,9 +235,9 @@ class ProcessGroupUCC : public ProcessGroup {
       ucc_coll_args_t& coll,
       std::unique_ptr<ProcessGroupUCC::WorkData> data,
       c10::Device dev,
-      std::vector<at::Tensor> &outputTensors,
-      const char* prof_title
-	);
+      std::vector<at::Tensor>& inputTensors,
+      std::vector<at::Tensor>& outputTensors,
+      const char* prof_title);
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
       std::vector<at::Tensor>& data,

--- a/include/torch_ucc_comm.hpp
+++ b/include/torch_ucc_comm.hpp
@@ -112,6 +112,8 @@ const std::map<torch_ucc_phase_t, std::string> ucc_phase_map = {
     {TORCH_UCC_FINALIZE, "FINALIZE"},
 };
 
+class CommTraceLogger;
+
 class TORCH_API ProcessGroupUCCLogger : public torch::CustomClassHolder {
  public:
   ProcessGroupUCCLogger();
@@ -123,9 +125,14 @@ class TORCH_API ProcessGroupUCCLogger : public torch::CustomClassHolder {
     local_phase = phase;
   }
 
+  void initCommsTracer();
+  void flushComms(int rank, int world_size);
+  std::shared_ptr<CommTraceLogger> trace_generator = nullptr;
+
  protected:
   std::string log_prefix;
   torch_ucc_phase_t local_phase = TORCH_UCC_UNKNOWN;
+  bool initialized_CommTraceLogger = false;
 };
 
 struct torch_ucc_oob_coll_info_t {

--- a/include/torch_ucc_tracing.hpp
+++ b/include/torch_ucc_tracing.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include "torch_ucc_comm.hpp"
+
+namespace c10d {
+
+#define RECORD_COMMS_TRACE(                                                    \
+    _comms_tracer, _work, _opType, _rank, _comm_size, _inTensors, _outTensors) \
+  do {                                                                         \
+    if (torch_ucc_config.enable_comms_logger) {                          \
+      _comms_tracer->recordComms(                                              \
+          opTypeToString(_opType),                                             \
+          (uintptr_t)_work.get(),                                              \
+          _rank,                                                               \
+          _comm_size,                                                          \
+          _inTensors,                                                          \
+          _outTensors);                                                        \
+    }                                                                          \
+  } while (0)
+
+class TORCH_API CommTraceLogger : public torch::CustomClassHolder {
+ private:
+  std::vector<std::string> comms_trace_;
+  std::vector<std::string> curBlocks_;
+  std::vector<int64_t> curOutSplitSizes_;
+  std::vector<int64_t> curInSplitSizes_;
+  int curRoot_ = -1;
+  unsigned long seqnum = 0;
+
+ public:
+  void setCurBlock(const std::string& name);            /* unused */
+  void popBlock();                                      /* unused */
+  void recordOptionalInfo(int root = -1);
+  void recordOptionalInfo(
+      const std::vector<int64_t>& outputSplitSizes = {},
+      const std::vector<int64_t>& inputSplitSizes = {});
+  void recordComms(
+      const std::string& collName,
+      const uintptr_t workReq = 0,
+      const int rank = -1,
+      const int world_size = -1,
+      const std::vector<at::Tensor>& inputTensors = {},
+      const std::vector<at::Tensor>& outputTensor = {});
+  std::vector<std::string>& getCommsTrace() {
+    return comms_trace_;
+  }
+};
+
+} // namespace c10d

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ def check_if_rocm_pytorch():
 IS_ROCM_PYTORCH = check_if_rocm_pytorch()
 
 plugin_sources      = ["src/torch_ucc.cpp",
-                       "src/torch_ucc_comm.cpp"]
+                       "src/torch_ucc_comm.cpp",
+                       "src/torch_ucc_tracing.cpp"]
 plugin_include_dirs = ["{}/include/".format(ucc_plugin_dir),
                        "{}/include/".format(ucx_home),
                        "{}/include/".format(ucc_home)]

--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -10,6 +10,7 @@
 
 #include "torch_ucc.hpp"
 #include "torch_ucc_comm.hpp"
+#include "torch_ucc_tracing.hpp"
 #include <memory>
 #include <list>
 
@@ -111,6 +112,7 @@ struct torch_ucc_config_t {
   std::once_flag flag;
   std::array<bool, 32> blocking_wait;
   bool enable_profiling;
+  bool enable_comms_logger;
   bool use_future;
   bool shared_comm;
   bool use_allgatherv;
@@ -124,6 +126,7 @@ std::map<std::string, std::string> torch_ucc_envs_map = {
     {"TORCH_UCC_ALLTOALL_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_BCAST_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_GATHER_BLOCKING_WAIT", "1"},
+    {"TORCH_UCC_ENABLE_COMMS_LOGGER", "0"},
     {"TORCH_UCC_REDUCE_SCATTER_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_SCATTER_BLOCKING_WAIT", "1"},
     {"TORCH_UCC_USE_FUTURE", "1"},
@@ -144,6 +147,7 @@ void read_confg() {
   torch_ucc_config.shared_comm = false;
   torch_ucc_config.use_allgatherv = false;
   torch_ucc_config.enable_health_check = false;
+  torch_ucc_config.enable_comms_logger = false;
 
   // read all torch_ucc env. variables and update the map
   char* env;
@@ -179,6 +183,8 @@ void read_confg() {
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_USE_ALLGATHERV"));
   torch_ucc_config.enable_health_check =
       std::stoi(torch_ucc_envs_map.at("TORCH_UCC_ENABLE_HEALTH_CHECK"));
+  torch_ucc_config.enable_comms_logger =
+      std::stoi(torch_ucc_envs_map.at("TORCH_UCC_ENABLE_COMMS_LOGGER"));
 }
 
 void check_device(c10::Device dev1, c10::Device dev2) {
@@ -240,6 +246,12 @@ bool ProcessGroupUCC::WorkUCC::isSuccess() const {
 }
 
 bool ProcessGroupUCC::WorkUCC::wait(std::chrono::milliseconds /* unused */) {
+  if (torch_ucc_config.enable_comms_logger && !logger_) {
+    logger_->trace_generator->recordComms(
+        "wait",
+        (uintptr_t) this,
+        rank_);
+  }
 #ifdef USE_CUDA
   if (fence && !torch_ucc_config.blocking_wait[(int)opType_]) {
     // block user stream
@@ -554,7 +566,8 @@ c10::intrusive_ptr<ProcessGroup::Work> CommPG::enqueue_p2p(
     OpType opType,
     ucc_coll_req_h request,
     const char* prof_title) {
-  auto work = c10::make_intrusive<ProcessGroupUCC::WorkUCC>(opType, prof_title);
+  auto work = c10::make_intrusive<ProcessGroupUCC::WorkUCC>(
+      opType, prof_title, logger);
   if (torch_ucc_config.use_future) {
     work->future_ = c10::make_intrusive<at::ivalue::Future>(
         c10::ListType::create(c10::TensorType::get()));
@@ -717,9 +730,15 @@ ProcessGroupUCC::ProcessGroupUCC(
     // are hangs, the main thread can still run correctly.
     runHealthCheck();
   }
+  if (torch_ucc_config.enable_comms_logger) {
+    logger->initCommsTracer();
+  }
 }
 
 ProcessGroupUCC::~ProcessGroupUCC() {
+  if (torch_ucc_config.enable_comms_logger) {
+    logger->flushComms(this->getRank(), this->getSize());
+  }
   if (comm) {
     logger->setPhase(TORCH_UCC_FINALIZE);
     comm->ucc_destroy_team(team);
@@ -896,11 +915,21 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::collective_post(
     ucc_coll_args_t& coll,
     std::unique_ptr<ProcessGroupUCC::WorkData> data,
     c10::Device dev,
+    std::vector<at::Tensor> &inputTensors,
     std::vector<at::Tensor> &outputTensors,
     const char* prof_title) {
   set_timeout(coll);
   auto work = c10::make_intrusive<ProcessGroupUCC::WorkUCC>(
-      opType, torch_ucc_config.enable_profiling ? prof_title : nullptr);
+      opType, torch_ucc_config.enable_profiling ? prof_title : nullptr, logger);
+
+  RECORD_COMMS_TRACE(
+      logger->trace_generator,
+      work,
+      opType,
+      this->getRank(),
+      this->getSize(),
+      inputTensors,
+      outputTensors);
 
   // Store references to outputs to be used by result
   work->outputs_ = std::make_shared<std::vector<at::Tensor>>(outputTensors);
@@ -995,6 +1024,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::allgather(
         coll,
         std::unique_ptr<WorkData>(data),
         tensor.device(),
+        inputTensors,
         outputTensors[0],
         "ucc:allgatherv");
   } else {
@@ -1049,6 +1079,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::allgather(
         coll,
         std::unique_ptr<WorkData>(data),
         tensor.device(),
+        inputTensors,
         outputTensors[0],
         "ucc:allgather");
   }
@@ -1093,6 +1124,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::_allgather_base(
       coll,
       std::unique_ptr<WorkData>(data),
       outputTensor.device(),
+      inputTensors,
       outputTensors,
       "ucc:allgather_base");
 }
@@ -1124,6 +1156,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::allreduce(
   coll.dst.info.datatype = to_ucc_dType(tensor);
   coll.dst.info.mem_type = to_ucc_memType(tensor.device().type());
   SAVE_TENSORS(tensors, data->dst);
+
   return collective_post(
       OpType::ALLREDUCE,
       []() {},
@@ -1131,6 +1164,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::allreduce(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
+      tensors,
       tensors,
       "ucc:allreduce");
 }
@@ -1209,6 +1243,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::alltoall(
       coll,
       std::unique_ptr<WorkData>(data),
       device,
+      inputTensors,
       outputTensors,
       "ucc:alltoall");
 }
@@ -1274,6 +1309,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::alltoall_base(
         UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER |
         UCC_COLL_ARGS_FLAG_COUNT_64BIT |
         UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+
+    if (torch_ucc_config.enable_comms_logger) {
+      logger->trace_generator->recordOptionalInfo(outputSplitSizes, inputSplitSizes);
+    }
   }
   std::vector<at::Tensor> inputTensors = {inputTensor};
   std::vector<at::Tensor> outputTensors = {outputTensor};
@@ -1287,6 +1326,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::alltoall_base(
       coll,
       std::unique_ptr<WorkData>(data),
       inputTensor.device(),
+      inputTensors,
       outputTensors,
       "ucc:alltoall");
 }
@@ -1340,6 +1380,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::barrier(
       nullptr,
       device,
       dummy_tensor,
+      dummy_tensor,
       "ucc:barrier");
 }
 
@@ -1367,6 +1408,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::broadcast(
   coll.root = opts.rootRank;
   SAVE_TENSORS(tensors, data->dst);
 
+  if (torch_ucc_config.enable_comms_logger) {
+    logger->trace_generator->recordOptionalInfo(opts.rootRank);
+  }
+
   return collective_post(
       OpType::BROADCAST,
       []() {},
@@ -1374,6 +1419,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::broadcast(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
+      tensors,
       tensors,
       "ucc:broadcast");
 }
@@ -1460,6 +1506,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::gather(
       coll,
       std::unique_ptr<WorkData>(data),
       input.device(),
+      inputTensors,
       outputs,
       "ucc:gather");
 }
@@ -1499,6 +1546,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::reduce(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
+      tensors,
       tensors,
       "ucc:reduce");
 }
@@ -1571,6 +1619,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::reduce_scatter(
     	coll,
     	std::move(data),
     	inputTensors[0][0].device(),
+      inputTensors[0],
     	outputTensors,
     	"ucc:reduce_scatter");
 }
@@ -1648,6 +1697,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::scatter(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
+      inputTensors[0],
       outputTensors,
       "ucc:scatter");
 }
@@ -1668,7 +1718,18 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::send(
       to_ucs_memType(tensor.device().type()),
       tensor.numel() * tensor.element_size(),
       ucp_tag);
-  return comm->enqueue_p2p(OpType::SEND, request, "ucc:send");
+
+  auto work = comm->enqueue_p2p(OpType::SEND, request, "ucc:send");
+  // TODO: record src, dst ranks and tag
+  RECORD_COMMS_TRACE(
+      logger->trace_generator,
+      work,
+      OpType::SEND,
+      this->getRank(),
+      this->getSize(),
+      tensors,
+      tensors);
+  return work;
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::recv(
@@ -1687,7 +1748,18 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::recv(
       tensor.numel() * tensor.element_size(),
       ucp_tag,
       ucp_tag_mask);
-  return comm->enqueue_p2p(OpType::RECV, request, "ucc:recv");
+
+  auto work = comm->enqueue_p2p(OpType::RECV, request, "ucc:recv");
+  // TODO: record src, dst ranks and tag
+  RECORD_COMMS_TRACE(
+      logger->trace_generator,
+      work,
+      OpType::RECV,
+      this->getRank(),
+      this->getSize(),
+      tensors,
+      tensors);
+  return work;
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::recvAnysource(
@@ -1706,7 +1778,18 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::recvAnysource(
       tensor.numel() * tensor.element_size(),
       ucp_tag,
       ucp_tag_mask);
-  return comm->enqueue_p2p(OpType::RECVANYSOURCE, request, "ucc:recv");
+
+  auto work = comm->enqueue_p2p(OpType::RECVANYSOURCE, request, "ucc:recv");
+  // TODO: record dst rank and tag
+  RECORD_COMMS_TRACE(
+      logger->trace_generator,
+      work,
+      OpType::RECVANYSOURCE,
+      this->getRank(),
+      this->getSize(),
+      tensors,
+      tensors);
+  return work;
 }
 
 c10::intrusive_ptr<ProcessGroup> ProcessGroupUCC::createProcessGroupUCC(

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "torch_ucc_comm.hpp"
+#include "torch_ucc_tracing.hpp"
 
 namespace c10d {
 

--- a/src/torch_ucc_tracing.cpp
+++ b/src/torch_ucc_tracing.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include "torch_ucc_tracing.hpp"
+#include "torch_ucc_comm.hpp"
+
+#include <c10d/ParamCommsUtils.hpp>
+
+#include <sys/stat.h>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+
+#ifdef FBCODE_CAFFE2
+#include "torch_ucc_internal_utils.hpp"
+#endif
+
+namespace c10d {
+
+void ProcessGroupUCCLogger::initCommsTracer() {
+  trace_generator = std::make_shared<CommTraceLogger>();
+  initialized_CommTraceLogger = true;
+}
+
+void ProcessGroupUCCLogger::flushComms(int rank, int world_size) {
+  if (!initialized_CommTraceLogger ||
+      trace_generator->getCommsTrace().empty()) {
+    return;
+  }
+
+  time_t now_ = time(0);
+  tm* ltm = localtime(&now_);
+  std::string dirname = c10::str(
+      "ProcessGroupUCC_trace_np",
+      world_size,
+      "_",
+      (1 + ltm->tm_mon),
+      "_",
+      ltm->tm_mday,
+      "_",
+      (1900 + ltm->tm_year));
+  std::string fullpath = "/tmp/" + dirname;
+  char* user_path = std::getenv("TORCH_UCC_COMMS_TRACE_OUTPUT_DIR");
+  if (user_path) {
+    fullpath = user_path;
+  }
+  std::string trace_filename = c10::str(fullpath, "/rank", rank, ".json");
+  std::ofstream _outfile;
+  if (!_outfile.is_open()) {
+    if (!mkdir(fullpath.c_str(), 0777)) {
+      LOG(INFO) << getLogPrefix() << "[INFO] failed to mkdir " << fullpath;
+    } else if (errno != EEXIST) {
+      return;
+    }
+    _outfile.open(trace_filename, std::ofstream::out | std::ofstream::trunc);
+  }
+  // flush the traced comms
+  if (_outfile.is_open()) {
+    _outfile << "[" << c10::Join(",", trace_generator->getCommsTrace())
+             << "\n]";
+    _outfile.flush();
+    _outfile.close();
+  }
+#ifdef FBCODE_CAFFE2
+  uploadTrace_internal(
+      trace_filename, dirname, c10::str("rank", rank, ".json"));
+#endif
+}
+
+/* unused */
+void CommTraceLogger::setCurBlock(const std::string& name) {
+  curBlocks_.push_back(
+      c10::str("\"", name, "\"")); // add quote marks for JSON format
+}
+
+/* unused */
+void CommTraceLogger::popBlock() {
+  // TODO: remove specific name
+  curBlocks_.pop_back();
+}
+
+void CommTraceLogger::recordOptionalInfo(int root) {
+  curRoot_ = root;
+}
+
+void CommTraceLogger::recordOptionalInfo(
+    const std::vector<int64_t>& outputSplitSizes,
+    const std::vector<int64_t>& inputSplitSizes) {
+  curOutSplitSizes_ = outputSplitSizes;
+  curInSplitSizes_ = inputSplitSizes;
+}
+
+void CommTraceLogger::recordComms(
+    const std::string& commName,
+    const uintptr_t workReq,
+    const int rank,
+    const int world_size,
+    const std::vector<at::Tensor>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors) {
+  auto inSize = (inputTensors.size() > 0) ? inputTensors[0].numel() : 0;
+  auto outSize = (outputTensors.size() > 0) ? outputTensors[0].numel() : 0;
+  auto dtype =
+      (outputTensors.size() > 0) ? outputTensors[0].scalar_type() : at::kByte;
+  auto devType = (outputTensors.size() > 0) ? outputTensors[0].device().type()
+                                            : c10::DeviceType::CPU;
+  auto now = std::chrono::system_clock::now();
+  static auto startTS = now;
+  int64_t time_since_begin =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(now - startTS)
+          .count();
+
+  // TODO: get markers from torch profiler if enabled
+
+  // common fields for all operations
+  std::string cur_trace_ = c10::str(
+      "\n\t\t\"markers\": [",
+      curBlocks_,
+      "]",
+      ",\n\t\t\"startTime_ns\": ",
+      time_since_begin,
+      ",\n\t\t\"comms\": \"",
+      commName,
+      "\"",
+      ",\n\t\t\"req\": ",
+      workReq,
+      ",\n\t\t\"seqnum\": ",
+      seqnum++,
+      ",\n\t\t\"world_size\": ",
+      world_size);
+
+  if (inSize > 0 || outSize > 0) {
+    // for most collectives - append msg sizes, data type, device type
+    cur_trace_ = c10::str(
+        cur_trace_,
+        ",\n\t\t\"in_msg_size\": ",
+        inSize,
+        ",\n\t\t\"out_msg_size\": ",
+        outSize,
+        ",\n\t\t\"dtype\": \"",
+        at::toString(dtype),
+        "\",\n\t\t\"devType\": \"",
+        c10::DeviceTypeName(devType),
+        "\"");
+  }
+  if (curRoot_ != -1) {
+    // append root rank if applicable, e.g., broadcast, gather, scatter
+    cur_trace_ = c10::str(cur_trace_, ",\n\t\t\"root\": ", curRoot_);
+  }
+  if (curInSplitSizes_.size() > 0 || curOutSplitSizes_.size() > 0) {
+    // append input and output splits if applicable, e.g., ALLTOALL_BASE
+    cur_trace_ = c10::str(
+        cur_trace_,
+        ",\n\t\t\"in_split\": [",
+        c10::Join(",", curInSplitSizes_),
+        "]"
+        ",\n\t\t\"out_split\": [",
+        c10::Join(",", curOutSplitSizes_),
+        "]");
+  }
+  comms_trace_.push_back(c10::str("\n\t{", cur_trace_, "\n\t}"));
+
+  // record the trace to kineto trace if applicable
+  RECORD_PARAM_COMMS(
+      rank,
+      commName.c_str(),
+      inSize,
+      outSize,
+      dtype,
+      curInSplitSizes_,
+      curOutSplitSizes_);
+
+  // reset optional field
+  curRoot_ = -1;
+  curInSplitSizes_ = {};
+  curOutSplitSizes_ = {};
+}
+
+} // namespace c10d


### PR DESCRIPTION
Summary:
- each rank will dump the profiled communication operations to a file when deconstructing ProcessGroupUCC (default output directory: `/tmp/ProcessGroupUCC_trace_np<# of processes>_<date>`).b/master/train/comms/pt/commsTraceReplay.py)
  - set `TORCH_UCC_ENABLE_COMMS_LOGGER=1` to enable the feature
  - change `TORCH_UCC_TRACE_OUTPUT_DIR` to specify the output directory (default is `/tmp`)
  - each rank will dump the profiled communication operations to a file  when deconstructing ProcessGroupUCC (default output directory: `/tmp/ProcessGroupUCC_trace_np<# of processes>_<date>`).

Example trace entry:
```
{
      "marker_stack": [],
      "startTime_ns": 10859489800,
      "comms": "ALLTOALL_BASE",
      "req": 139911179580672,
      "seqnum": 32,
      "world_size": 16,
      "in_msg_size": 379904,
      "out_msg_size": 393216,
      "dtype": "Int",
      "devType": "CUDA",
      "in_split": [21504, 22528, 23040, 22528, 22528, 23552, 24064, 24064, 24576, 24576, 24576, 24576, 24576, 25088, 24064, 24064],
      "out_split": [24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576, 24576]
    },
```

More implementation details:
- Define a new class `CommTraceLogger` in `torch_ucc_tracing.hpp` & `torch_ucc_tracing.cpp`
- `ProcessGroupUCCLogger::initCommsTracer()` initiate `CommTraceLogger` instance to be used for recording and flushing comm traces
- `RECORD_COMMS_TRACE` wraps us `CommTraceLogger::recordComm` to log new comm op
- passing both input and output tensors to `collective_post` to be used to figure out tensors' size and type

Differential Revision: D30267713

