### PR TITLE
remove team size 1 hack to support future object

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,7 +84,7 @@ jobs:
         export UCX_LOG_LEVEL=info
         export TORCH_UCC_ENABLE_HEALTH_CHECK=1
         export TORCH_SHOW_CPP_STACKTRACES=1
-        pip3 install expecttest hypothesis
+        pip3 install expecttest hypothesis xmlrunner unittest-xml-reporting
         cd test
         for np in `seq 4`
         do


### PR DESCRIPTION
Summary:
remove team size 1 hack to support associating future object that are required by some applications using ddp.

This requires latest UCC that can support team size 1 (i.e., https://github.com/openucx/ucc/pull/511)

Reviewed By: pallab-zz, minsii

Differential Revision: D36469834

