### PR TITLE
Fix compile issue with send/recv functions

### DIFF
--- a/src/torch_ucc.cpp
+++ b/src/torch_ucc.cpp
@@ -1691,6 +1691,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::send(
       std::unique_ptr<WorkData>(data),
       tensor.device(),
       tensors,
+      tensors,
       "ucc:send");
 #else
   ucp_tag_t ucp_tag;
@@ -1749,6 +1750,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupUCC::recv(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
+      tensors,
       tensors,
       "ucc:recv");
 #else


### PR DESCRIPTION
Summary:
There was a conflict between https://github.com/facebookresearch/torch_ucc/commit/beaed6519970441be0ecf05dfd359a5568b472ba and https://github.com/facebookresearch/torch_ucc/commit/7f4f023b62c4a70fa8bfb89c6979772737fbc676 that was resolved incorrectly and caused a compilation issue that I previously missed.

Differential Revision: D37389458

Fixes https://github.com/facebookresearch/torch_ucc/issues/92
