### PR TITLE
completely disable ucx when ACTIVE_SET is on

### DIFF
--- a/include/torch_ucc.hpp
+++ b/include/torch_ucc.hpp
@@ -323,7 +323,9 @@ class ProcessGroupUCC : public ProcessGroup {
   std::shared_ptr<torch_ucc_oob_coll_info_t> oob;
   std::shared_ptr<Comm> comm = {nullptr};
   uint32_t comm_id;
+#ifndef USE_ACTIVE_SETS
   std::vector<ucp_ep_h> eps;
+#endif
   ucc_team_h team {nullptr};
   ucc_ee_h cuda_ee {nullptr};
 #ifdef USE_CUDA
@@ -336,7 +338,9 @@ class ProcessGroupUCC : public ProcessGroup {
 class Comm {
   c10::intrusive_ptr<ProcessGroupUCCLogger> logger;
   std::shared_ptr<torch_ucc_oob_coll_info_t> oob;
+#ifndef USE_ACTIVE_SETS
   CommUCX ucx_comm;
+#endif
   CommUCC ucc_comm;
   std::mutex mutex;
   std::thread progress_thread;
@@ -355,6 +359,7 @@ class Comm {
 
   ~Comm();
 
+#ifndef USE_ACTIVE_SETS
   // Connects UCX end points.
   void ucx_connect_eps(
       std::vector<ucp_ep_h>& eps,
@@ -364,6 +369,7 @@ class Comm {
   void ucx_disconnect_eps(
       std::vector<ucp_ep_h>& eps,
       std::shared_ptr<torch_ucc_oob_coll_info_t> oob);
+#endif
 
   void ucc_create_team(
       ucc_team_h& team,
@@ -371,10 +377,12 @@ class Comm {
 
   void ucc_destroy_team(ucc_team_h& team);
 
+#ifndef USE_ACTIVE_SETS
   c10::intrusive_ptr<ProcessGroup::Work> enqueue_p2p(
       OpType opType,
       ucc_coll_req_h request,
       const char* prof_title);
+#endif
 
 #ifdef USE_CUDA
   void enqueue_cuda_collective(
@@ -400,6 +408,9 @@ class Comm {
 
   void progress_loop();
 
+#ifndef USE_ACTIVE_SETS
+  // Only used internally
+  // Unused when USE_ACTIVE_SETS is ON, thus safe to disable
   ucc_coll_req_h send_nb(
       ucp_ep_h ep,
       void* data,
@@ -413,6 +424,7 @@ class Comm {
       size_t size,
       ucp_tag_t ucp_tag,
       ucp_tag_t ucp_tag_mask);
+#endif
 };
 
 } // namespace c10d

--- a/include/torch_ucc_comm.hpp
+++ b/include/torch_ucc_comm.hpp
@@ -13,7 +13,9 @@
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/Store.hpp>
 #include <ucc/api/ucc.h>
+#ifndef USE_ACTIVE_SETS
 #include <ucp/api/ucp.h>
+#endif
 
 #define TORCH_UCX_COMM_BITS 15
 #define TORCH_UCX_RANK_BITS 16
@@ -61,6 +63,7 @@ namespace c10d {
     }                                     \
   } while (0)
 
+#ifndef USE_ACTIVE_SETS
 // Macro to throw on a non-successful UCX return value.
 #define TORCH_UCX_CHECK(_cmd, _error_msg) \
   do {                                    \
@@ -83,6 +86,7 @@ namespace c10d {
       TORCH_CHECK(false, err);            \
     }                                     \
   } while (0)
+#endif
 
 // Macros to print logs with unified format
 #define TORCH_UCC_LOG_ERROR(_phase, _msg) \
@@ -157,6 +161,7 @@ class CommBase {
   c10::intrusive_ptr<ProcessGroupUCCLogger> logger;
 };
 
+#ifndef USE_ACTIVE_SETS
 class CommUCX : public CommBase {
  public:
   ucp_context_h context{nullptr};
@@ -170,6 +175,7 @@ class CommUCX : public CommBase {
       const c10::intrusive_ptr<ProcessGroupUCCLogger>& logger);
   ~CommUCX();
 };
+#endif
 
 class CommUCC : public CommBase {
  public:

--- a/src/torch_ucc_comm.cpp
+++ b/src/torch_ucc_comm.cpp
@@ -19,6 +19,7 @@ constexpr char kAllGatherDone[] = "ag_done";
 constexpr char kAllGatherFree[] = "ag_free";
 } // namespace
 
+#ifndef USE_ACTIVE_SETS
 CommUCX::CommUCX(
     int comm_size,
     const c10::intrusive_ptr<ProcessGroupUCCLogger>& logger)
@@ -87,6 +88,7 @@ CommUCX::~CommUCX() {
   worker = nullptr;
   context = nullptr;
 }
+#endif
 
 ucc_status_t oob_allgather(
     void* sbuf,


### PR DESCRIPTION
Summary:
When UCC provides ACTIVE_SET feature, we can completely disable all ucx usage in torch_ucc and remove ucp and ucs dependencies.

Limitation of this commit:
The following API is not yet supported in the ACTIVE_SET version, thus simply report error.  It is the same behavior in NCCL PG: recvAnysource

Reviewed By: wesbland, kingchc

Differential Revision: D38142280

