### PR TITLE
Add the world size info in NCCL metadata

### DIFF
--- a/src/torch_ucc_tracing.cpp
+++ b/src/torch_ucc_tracing.cpp
@@ -176,7 +176,8 @@ void CommTraceLogger::recordComms(
       outSize,
       dtype,
       curInSplitSizes_,
-      curOutSplitSizes_);
+      curOutSplitSizes_,
+      world_size);
 
   ++seqnum;
 


### PR DESCRIPTION
Summary: This diff adds the world size info in NCCL metadata, as we need the information to calculate the algorithmic bandwidth and bus Bandwidth.

Differential Revision: D50439185


